### PR TITLE
Refactor handlebars object template

### DIFF
--- a/src/cli/export.js
+++ b/src/cli/export.js
@@ -24,6 +24,10 @@ function buildCommand(yargs) {
       describe: "The format to export to",
       default: "handlebars"
     })
+    .option("hb-style-sections", {
+      describe: "Export explicit object sections. Default is implicit sections",
+      default: false
+    })
     .option("config", {
       alias: "c",
       describe: "External configuration file to require"
@@ -35,7 +39,6 @@ function buildCommand(yargs) {
 }
 
 var exportCli = function (options) {
-
   commonCli(options);
 
   var output = options.output === "stdout" ? process.stdout : options.output;

--- a/src/cli/start.js
+++ b/src/cli/start.js
@@ -15,6 +15,10 @@ function buildCommand(yargs) {
       describe: "Root folder(s) for the web site",
       default: "."
     })
+    .option("hb-style-sections", {
+      describe: "Export explicit object sections. Default is implicit sections",
+      default: false
+    })
     .option("config", {
       alias: "c",
       describe: "External configuration file to require"

--- a/src/lib/export/to-handlebars/kvp.js
+++ b/src/lib/export/to-handlebars/kvp.js
@@ -3,6 +3,10 @@
 const util = require("util");
 const getMetadata = require("../../metadata-yaml");
 
+function createNewExportOptionsContext(options) {
+  return { hbStyleSections: options.hbStyleSections };
+}
+
 function exportObject(meta, cb, options) {
   var propertyNames = Object.getOwnPropertyNames(meta.children);
   var len = propertyNames.length;
@@ -11,20 +15,20 @@ function exportObject(meta, cb, options) {
   propertyNames.forEach((ckey, idx) => {
     let cmeta = meta.children[ckey];
     if(cmeta.more) cmeta = cmeta.more();
-    exportHandlebars(cmeta, cb);
+    exportHandlebars(cmeta, cb, createNewExportOptionsContext(options));
     if(idx + 1 !== len) cb(",");
   });
   cb(" }");
 }
 
-function exportArray(meta, cb) {
+function exportArray(meta, cb, options) {
   var kvp = meta.src;
   var len = kvp.value.length;
 
   cb("[");
   kvp.value.forEach((val, idx) => {
     let ckvp = { value: val };
-    exportHandlebars(getMetadata(ckvp), cb);
+    exportHandlebars(getMetadata(ckvp), cb, createNewExportOptionsContext(options));
     if(idx + 1 !== len) cb(",");
   });
   cb("]");
@@ -46,10 +50,35 @@ function exportLiteralTemplate(meta, cb, options) {
   cb("{{/if}}");
 }
 
-function exportObjectTemplate(meta, cb, options) {
+function exportImplicitObjectTemplate(meta, cb, options) {
+  function getInverseObjectTemplate(template) {
+    var inverseSymbol = template.symbol === "#" ? "^" : "#";
+    var inverseSection = template.section.replace(template.symbol, inverseSymbol);
+    return {
+      type: "object",
+      symbol: inverseSymbol,
+      section: inverseSection,
+      variable: template.variable
+    };
+  }
+
+  cb("{{" + meta.template.section + "}}");
+  exportObject(meta, cb, createNewExportOptionsContext(options));
+  cb("{{/" + meta.template.variable + "}}");
+
+  if(!options.noDefault) {
+    var defaultValue = meta.key === "value" ? null : emptyVsp();
+    var inverse = getInverseObjectTemplate(meta.template);
+    cb("{{" + inverse.section + "}}");
+    cb(JSON.stringify(defaultValue));
+    cb("{{/" + inverse.variable + "}}");
+  }
+}
+
+function exportExplicitObjectTemplate(meta, cb, options) {
   var block = meta.template.symbol === "#" ? "with" : "unless";
   cb("{{#" + block + " " + meta.template.variable + "}}");
-  exportObject(meta, cb);
+  exportObject(meta, cb, createNewExportOptionsContext(options));
   cb("{{/" + block + "}}");
 
   if(!options.noDefault) {
@@ -59,6 +88,11 @@ function exportObjectTemplate(meta, cb, options) {
     cb(JSON.stringify(defaultValue));
     cb("{{/" + inverseBlock + "}}");
   }
+}
+
+function exportObjectTemplate(meta, cb, options) {
+  if(options.hbStyleSections) exportExplicitObjectTemplate(meta, cb, options);
+  else exportImplicitObjectTemplate(meta, cb, options);
 }
 
 function emptyVsp() {
@@ -76,7 +110,7 @@ function exportArrayTemplate(meta, cb, options) {
   meta.src.value.forEach(itemTemplate => {
     let ckvp = { value: itemTemplate };
     let cmeta = getMetadata(ckvp);
-    exportHandlebars(cmeta, cb);
+    exportHandlebars(cmeta, cb, createNewExportOptionsContext(options));
   });
   cb("{{#unless @last}},{{/unless}}");
   cb("{{/each}}");
@@ -84,7 +118,6 @@ function exportArrayTemplate(meta, cb, options) {
 }
 
 function exportHandlebars(meta, cb, options) {
-  options = options || {};
 
   if(meta.key && !options.noKey) {
     cb(JSON.stringify(meta.key) + ":");
@@ -94,7 +127,7 @@ function exportHandlebars(meta, cb, options) {
     let len = meta.templates.length;
 
     meta.templates.forEach((cmeta, idx) => {
-      let coptions = {};
+      let coptions = createNewExportOptionsContext(options);
 
       if(len > 1) {
         coptions.noDefault = true;
@@ -115,16 +148,17 @@ function exportHandlebars(meta, cb, options) {
   } else if(util.isPrimitive(meta.src.value)) {
     cb(JSON.stringify(meta.src.value));
   } else if(Array.isArray(meta.src.value)) {
-    exportArray(meta, cb);
+    exportArray(meta, cb, options);
   } else if(meta.children) {
-    exportObject(meta, cb);
+    exportObject(meta, cb, options);
   }
 }
 
-function kvpToHandlebars(kvp) {
+function kvpToHandlebars(kvp, options) {
   var buffer = "";
   var meta = getMetadata(kvp);
-  exportHandlebars(meta, data => buffer += data);
+  var exportOptions = createNewExportOptionsContext(options);
+  exportHandlebars(meta, data => buffer += data, exportOptions);
   return buffer;
 }
 

--- a/src/lib/export/to-handlebars/kvp.js
+++ b/src/lib/export/to-handlebars/kvp.js
@@ -46,28 +46,18 @@ function exportLiteralTemplate(meta, cb, options) {
   cb("{{/if}}");
 }
 
-function getInverseObjectTemplate(template) {
-  var inverseSymbol = template.symbol === "#" ? "^" : "#";
-  var inverseSection = template.section.replace(template.symbol, inverseSymbol);
-  return {
-    type: "object",
-    symbol: inverseSymbol,
-    section: inverseSection,
-    variable: template.variable
-  };
-}
-
 function exportObjectTemplate(meta, cb, options) {
-  cb("{{" + meta.template.section + "}}");
+  var block = meta.template.symbol === "#" ? "with" : "unless";
+  cb("{{#" + block + " " + meta.template.variable + "}}");
   exportObject(meta, cb);
-  cb("{{/" + meta.template.variable + "}}");
+  cb("{{/" + block + "}}");
 
   if(!options.noDefault) {
+    var inverseBlock = meta.template.symbol === "#" ? "unless" : "with";
     var defaultValue = meta.key === "value" ? null : emptyVsp();
-    var inverse = getInverseObjectTemplate(meta.template);
-    cb("{{" + inverse.section + "}}");
+    cb("{{#" + inverseBlock + " " + meta.template.variable + "}}");
     cb(JSON.stringify(defaultValue));
-    cb("{{/" + inverse.variable + "}}");
+    cb("{{/" + inverseBlock + "}}");
   }
 }
 

--- a/test/lib/export/to-handlebars/kvp.js
+++ b/test/lib/export/to-handlebars/kvp.js
@@ -143,7 +143,7 @@ var tests = [{
     value: {
       greeting: "Hi"
     },
-    expected: '"key":{{#key}}{"greeting":"Hi" }{{/key}}{{^key}}{"spec":{"hints":["container"]},"value":null}{{/key}}',
+    expected: '"key":{{#with key}}{"greeting":"Hi" }{{/with}}{{#unless key}}{"spec":{"hints":["container"]},"value":null}{{/unless}}',
     should: "a kvp with a single object template should export a kvp with an object value template and a null fallback value"
   },
   {
@@ -151,7 +151,7 @@ var tests = [{
     value: {
       "greeting<": "Hi"
     },
-    expected: '"key":{{#key}}{"greeting":{{#if greeting}}"{{greeting}}"{{else}}"Hi"{{/if}} }{{/key}}{{^key}}{"spec":{"hints":["container"]},"value":null}{{/key}}',
+    expected: '"key":{{#with key}}{"greeting":{{#if greeting}}"{{greeting}}"{{else}}"Hi"{{/if}} }{{/with}}{{#unless key}}{"spec":{"hints":["container"]},"value":null}{{/unless}}',
     should: "a kvp with a single object template with a single value template should export correctly"
   },
   {
@@ -160,7 +160,7 @@ var tests = [{
       "greeting<": null,
       "greeting<alternateGreeting": null
     },
-    expected: '"key":{{#key}}{"greeting":{{#if greeting}}"{{greeting}}"{{/if}}{{#if alternateGreeting}}"{{alternateGreeting}}"{{/if}} }{{/key}}{{^key}}{"spec":{"hints":["container"]},"value":null}{{/key}}',
+    expected: '"key":{{#with key}}{"greeting":{{#if greeting}}"{{greeting}}"{{/if}}{{#if alternateGreeting}}"{{alternateGreeting}}"{{/if}} }{{/with}}{{#unless key}}{"spec":{"hints":["container"]},"value":null}{{/unless}}',
     should: "a kvp with a single object template with multiple value templates should export correctly without a value template fallback/default value"
   },
   {
@@ -168,7 +168,7 @@ var tests = [{
     value: {
       greeting: "Hi"
     },
-    expected: '"key":{{^key}}{"greeting":"Hi" }{{/key}}{{#key}}{"spec":{"hints":["container"]},"value":null}{{/key}}',
+    expected: '"key":{{#unless key}}{"greeting":"Hi" }{{/unless}}{{#with key}}{"spec":{"hints":["container"]},"value":null}{{/with}}',
     should: "a kvp with a single negative object template should export a kvp with an object value template and a null fallback value"
   },
   {
@@ -181,7 +181,7 @@ var tests = [{
         label: "Secondary Contact"
       }
     },
-    expected: '{"contact":{{#isPrimary}}{"label":"Primary Contact" }{{/isPrimary}}{{#isSecondary}}{"label":"Secondary Contact" }{{/isSecondary}} }',
+    expected: '{"contact":{{#with isPrimary}}{"label":"Primary Contact" }{{/with}}{{#with isSecondary}}{"label":"Secondary Contact" }{{/with}} }',
     should: "a kvp with a multiple object templates should export a kvp with multiple object templates"
   },
   {
@@ -194,7 +194,7 @@ var tests = [{
         label: "Secondary Contact"
       }
     },
-    expected: '{"contact":{{#isPrimary}}{"label":"Primary Contact" }{{/isPrimary}}{{^isPrimary}}{"label":"Secondary Contact" }{{/isPrimary}} }',
+    expected: '{"contact":{{#with isPrimary}}{"label":"Primary Contact" }{{/with}}{{#unless isPrimary}}{"label":"Secondary Contact" }{{/unless}} }',
     should: "a kvp with a multiple object templates should export a kvp with multiple object templates"
   },
   {
@@ -207,7 +207,7 @@ var tests = [{
         name: "One"
       }
     },
-    expected: '{"spec":{"hints":["container"] },"value":{{#v1}}{"name":"One" }{{/v1}}{{^v1}}null{{/v1}} }',
+    expected: '{"spec":{"hints":["container"] },"value":{{#with v1}}{"name":"One" }{{/with}}{{#unless v1}}null{{/unless}} }',
     should: "a kvp with a dynamic value template with no inverse should export a kvp with null inverse"
   },
   {
@@ -223,7 +223,7 @@ var tests = [{
         name: "None"
       }
     },
-    expected: '{"spec":{"hints":["container"] },"value":{{#v1}}{"name":"One" }{{/v1}}{{^v1}}{"name":"None" }{{/v1}} }',
+    expected: '{"spec":{"hints":["container"] },"value":{{#with v1}}{"name":"One" }{{/with}}{{#unless v1}}{"name":"None" }{{/unless}} }',
     should: "a kvp with a dynamic value template with explicit inverse should export a kvp with explicit inverse"
   },
   {
@@ -239,7 +239,7 @@ var tests = [{
         name: "None"
       }
     },
-    expected: '{"spec":{"hints":["container"] },"flag":{{#flag}}{"name":"One" }{{/flag}}{{^flag}}{"name":"None" }{{/flag}} }',
+    expected: '{"spec":{"hints":["container"] },"flag":{{#with flag}}{"name":"One" }{{/with}}{{#unless flag}}{"name":"None" }{{/unless}} }',
     should: "a kvp with a dynamic value template with explicit inverse and with no variable should export a kvp with explicit inverse"
   },
   {
@@ -255,7 +255,7 @@ var tests = [{
         name: "Two"
       }
     },
-    expected: '{"spec":{"hints":["container"] },"value":{{#v1}}{"name":"One" }{{/v1}}{{#v2}}{"name":"Two" }{{/v2}} }',
+    expected: '{"spec":{"hints":["container"] },"value":{{#with v1}}{"name":"One" }{{/with}}{{#with v2}}{"name":"Two" }{{/with}} }',
     should: "a kvp with a multiple value templates should export a kvp with values in blocks"
   },
   {

--- a/test/lib/export/to-handlebars/kvp.js
+++ b/test/lib/export/to-handlebars/kvp.js
@@ -4,7 +4,7 @@ var should = require("chai").should();
 var kvpToHandlebars = require("../../../../src/lib/export/to-handlebars/kvp");
 
 function runTest(test) {
-  var actual = kvpToHandlebars({ key: test.key, value: test.value });
+  var actual = kvpToHandlebars({ key: test.key, value: test.value }, test.options || {});
   actual.should.equal(test.expected);
 }
 
@@ -143,7 +143,7 @@ var tests = [{
     value: {
       greeting: "Hi"
     },
-    expected: '"key":{{#with key}}{"greeting":"Hi" }{{/with}}{{#unless key}}{"spec":{"hints":["container"]},"value":null}{{/unless}}',
+    expected: '"key":{{#key}}{"greeting":"Hi" }{{/key}}{{^key}}{"spec":{"hints":["container"]},"value":null}{{/key}}',
     should: "a kvp with a single object template should export a kvp with an object value template and a null fallback value"
   },
   {
@@ -151,7 +151,7 @@ var tests = [{
     value: {
       "greeting<": "Hi"
     },
-    expected: '"key":{{#with key}}{"greeting":{{#if greeting}}"{{greeting}}"{{else}}"Hi"{{/if}} }{{/with}}{{#unless key}}{"spec":{"hints":["container"]},"value":null}{{/unless}}',
+    expected: '"key":{{#key}}{"greeting":{{#if greeting}}"{{greeting}}"{{else}}"Hi"{{/if}} }{{/key}}{{^key}}{"spec":{"hints":["container"]},"value":null}{{/key}}',
     should: "a kvp with a single object template with a single value template should export correctly"
   },
   {
@@ -160,7 +160,7 @@ var tests = [{
       "greeting<": null,
       "greeting<alternateGreeting": null
     },
-    expected: '"key":{{#with key}}{"greeting":{{#if greeting}}"{{greeting}}"{{/if}}{{#if alternateGreeting}}"{{alternateGreeting}}"{{/if}} }{{/with}}{{#unless key}}{"spec":{"hints":["container"]},"value":null}{{/unless}}',
+    expected: '"key":{{#key}}{"greeting":{{#if greeting}}"{{greeting}}"{{/if}}{{#if alternateGreeting}}"{{alternateGreeting}}"{{/if}} }{{/key}}{{^key}}{"spec":{"hints":["container"]},"value":null}{{/key}}',
     should: "a kvp with a single object template with multiple value templates should export correctly without a value template fallback/default value"
   },
   {
@@ -168,7 +168,7 @@ var tests = [{
     value: {
       greeting: "Hi"
     },
-    expected: '"key":{{#unless key}}{"greeting":"Hi" }{{/unless}}{{#with key}}{"spec":{"hints":["container"]},"value":null}{{/with}}',
+    expected: '"key":{{^key}}{"greeting":"Hi" }{{/key}}{{#key}}{"spec":{"hints":["container"]},"value":null}{{/key}}',
     should: "a kvp with a single negative object template should export a kvp with an object value template and a null fallback value"
   },
   {
@@ -181,7 +181,7 @@ var tests = [{
         label: "Secondary Contact"
       }
     },
-    expected: '{"contact":{{#with isPrimary}}{"label":"Primary Contact" }{{/with}}{{#with isSecondary}}{"label":"Secondary Contact" }{{/with}} }',
+    expected: '{"contact":{{#isPrimary}}{"label":"Primary Contact" }{{/isPrimary}}{{#isSecondary}}{"label":"Secondary Contact" }{{/isSecondary}} }',
     should: "a kvp with a multiple object templates should export a kvp with multiple object templates"
   },
   {
@@ -194,7 +194,7 @@ var tests = [{
         label: "Secondary Contact"
       }
     },
-    expected: '{"contact":{{#with isPrimary}}{"label":"Primary Contact" }{{/with}}{{#unless isPrimary}}{"label":"Secondary Contact" }{{/unless}} }',
+    expected: '{"contact":{{#isPrimary}}{"label":"Primary Contact" }{{/isPrimary}}{{^isPrimary}}{"label":"Secondary Contact" }{{/isPrimary}} }',
     should: "a kvp with a multiple object templates should export a kvp with multiple object templates"
   },
   {
@@ -207,7 +207,7 @@ var tests = [{
         name: "One"
       }
     },
-    expected: '{"spec":{"hints":["container"] },"value":{{#with v1}}{"name":"One" }{{/with}}{{#unless v1}}null{{/unless}} }',
+    expected: '{"spec":{"hints":["container"] },"value":{{#v1}}{"name":"One" }{{/v1}}{{^v1}}null{{/v1}} }',
     should: "a kvp with a dynamic value template with no inverse should export a kvp with null inverse"
   },
   {
@@ -223,7 +223,7 @@ var tests = [{
         name: "None"
       }
     },
-    expected: '{"spec":{"hints":["container"] },"value":{{#with v1}}{"name":"One" }{{/with}}{{#unless v1}}{"name":"None" }{{/unless}} }',
+    expected: '{"spec":{"hints":["container"] },"value":{{#v1}}{"name":"One" }{{/v1}}{{^v1}}{"name":"None" }{{/v1}} }',
     should: "a kvp with a dynamic value template with explicit inverse should export a kvp with explicit inverse"
   },
   {
@@ -239,7 +239,7 @@ var tests = [{
         name: "None"
       }
     },
-    expected: '{"spec":{"hints":["container"] },"flag":{{#with flag}}{"name":"One" }{{/with}}{{#unless flag}}{"name":"None" }{{/unless}} }',
+    expected: '{"spec":{"hints":["container"] },"flag":{{#flag}}{"name":"One" }{{/flag}}{{^flag}}{"name":"None" }{{/flag}} }',
     should: "a kvp with a dynamic value template with explicit inverse and with no variable should export a kvp with explicit inverse"
   },
   {
@@ -255,8 +255,138 @@ var tests = [{
         name: "Two"
       }
     },
-    expected: '{"spec":{"hints":["container"] },"value":{{#with v1}}{"name":"One" }{{/with}}{{#with v2}}{"name":"Two" }{{/with}} }',
+    expected: '{"spec":{"hints":["container"] },"value":{{#v1}}{"name":"One" }{{/v1}}{{#v2}}{"name":"Two" }{{/v2}} }',
     should: "a kvp with a multiple value templates should export a kvp with values in blocks"
+  },
+  {
+    key: "key#",
+    value: {
+      greeting: "Hi"
+    },
+    options: { hbStyleSections: true },
+    expected: '"key":{{#with key}}{"greeting":"Hi" }{{/with}}{{#unless key}}{"spec":{"hints":["container"]},"value":null}{{/unless}}',
+    should: "with handlebars style sections a kvp with a single object template should export a kvp with an object value template and a null fallback value"
+  },
+  {
+    key: "key#",
+    value: {
+      "greeting<": "Hi"
+    },
+    options: { hbStyleSections: true },
+    expected: '"key":{{#with key}}{"greeting":{{#if greeting}}"{{greeting}}"{{else}}"Hi"{{/if}} }{{/with}}{{#unless key}}{"spec":{"hints":["container"]},"value":null}{{/unless}}',
+    should: "with handlebars style sections a kvp with a single object template with a single value template should export correctly"
+  },
+  {
+    key: "key#",
+    value: {
+      "greeting<": null,
+      "greeting<alternateGreeting": null
+    },
+    options: { hbStyleSections: true },
+    expected: '"key":{{#with key}}{"greeting":{{#if greeting}}"{{greeting}}"{{/if}}{{#if alternateGreeting}}"{{alternateGreeting}}"{{/if}} }{{/with}}{{#unless key}}{"spec":{"hints":["container"]},"value":null}{{/unless}}',
+    should: "with handlebars style sections a kvp with a single object template with multiple value templates should export correctly without a value template fallback/default value"
+  },
+  {
+    key: "key^",
+    value: {
+      greeting: "Hi"
+    },
+    options: { hbStyleSections: true },
+    expected: '"key":{{#unless key}}{"greeting":"Hi" }{{/unless}}{{#with key}}{"spec":{"hints":["container"]},"value":null}{{/with}}',
+    should: "with handlebars style sections a kvp with a single negative object template should export a kvp with an object value template and a null fallback value"
+  },
+  {
+    key: undefined,
+    value: {
+      "contact#isPrimary": {
+        label: "Primary Contact"
+      },
+      "contact#isSecondary": {
+        label: "Secondary Contact"
+      }
+    },
+    options: { hbStyleSections: true },
+    expected: '{"contact":{{#with isPrimary}}{"label":"Primary Contact" }{{/with}}{{#with isSecondary}}{"label":"Secondary Contact" }{{/with}} }',
+    should: "with handlebars style sections a kvp with a multiple object templates should export a kvp with multiple object templates"
+  },
+  {
+    key: undefined,
+    value: {
+      "contact#isPrimary": {
+        label: "Primary Contact"
+      },
+      "contact^isPrimary": {
+        label: "Secondary Contact"
+      }
+    },
+    options: { hbStyleSections: true },
+    expected: '{"contact":{{#with isPrimary}}{"label":"Primary Contact" }{{/with}}{{#unless isPrimary}}{"label":"Secondary Contact" }{{/unless}} }',
+    should: "with handlebars style sections a kvp with a multiple object templates should export a kvp with multiple object templates"
+  },
+  {
+    key: undefined,
+    value: {
+      spec: {
+        hints: ["container"]
+      },
+      "value#v1": {
+        name: "One"
+      }
+    },
+    options: { hbStyleSections: true },
+    expected: '{"spec":{"hints":["container"] },"value":{{#with v1}}{"name":"One" }{{/with}}{{#unless v1}}null{{/unless}} }',
+    should: "with handlebars style sections a kvp with a dynamic value template with no inverse should export a kvp with null inverse"
+  },
+  {
+    key: undefined,
+    value: {
+      spec: {
+        hints: ["container"]
+      },
+      "value#v1": {
+        name: "One"
+      },
+      "value^v1": {
+        name: "None"
+      }
+    },
+    options: { hbStyleSections: true },
+    expected: '{"spec":{"hints":["container"] },"value":{{#with v1}}{"name":"One" }{{/with}}{{#unless v1}}{"name":"None" }{{/unless}} }',
+    should: "with handlebars style sections a kvp with a dynamic value template with explicit inverse should export a kvp with explicit inverse"
+  },
+  {
+    key: undefined,
+    value: {
+      spec: {
+        hints: ["container"]
+      },
+      "flag#": {
+        name: "One"
+      },
+      "flag^": {
+        name: "None"
+      }
+    },
+    options: { hbStyleSections: true },
+    expected: '{"spec":{"hints":["container"] },"flag":{{#with flag}}{"name":"One" }{{/with}}{{#unless flag}}{"name":"None" }{{/unless}} }',
+    should: "with handlebars style sections a kvp with a dynamic value template with explicit inverse and with no variable should export a kvp with explicit inverse"
+  },
+  {
+    key: undefined,
+    value: {
+      spec: {
+        hints: ["container"]
+      },
+      "value#v1": {
+        name: "One"
+      },
+      "value#v2": {
+        name: "Two"
+      }
+    },
+    options: { hbStyleSections: true },
+    expected: '{"spec":{"hints":["container"] },"value":{{#with v1}}{"name":"One" }{{/with}}{{#with v2}}{"name":"Two" }{{/with}} }',
+    should: "with handlebars style sections a kvp with a multiple value templates should export a kvp with values in blocks"
   },
   {
     key: "items@",

--- a/test/lib/partials/header.js
+++ b/test/lib/partials/header.js
@@ -1,31 +1,32 @@
 var tests = [
-//   {
-//   description: "when array value",
-//   should: "have header hint and array value",
-//   kvp: {
-//     key: ">header",
-//     value: ["one", "two", "three"]
-//   },
-//   expected: {
-//     spec: { hints: ["header", "container"] },
-//     value: ["one", "two", "three"]
-//   },
-//   only: true
-// },
-{
-  description: "when text value",
-  should: "have header hint and a label with a text value",
-  kvp: {
-    key: ">header",
-    value: "Label"
-  },
-  expected: {
-    spec: { hints: ["header", "container"] },
-    value: {
-      "label": "Label"
+  //   {
+  //   description: "when array value",
+  //   should: "have header hint and array value",
+  //   kvp: {
+  //     key: ">header",
+  //     value: ["one", "two", "three"]
+  //   },
+  //   expected: {
+  //     spec: { hints: ["header", "container"] },
+  //     value: ["one", "two", "three"]
+  //   },
+  //   only: true
+  // },
+  {
+    description: "when text value",
+    should: "have header hint and a label with a text value",
+    kvp: {
+      key: ">header",
+      value: "Label"
+    },
+    expected: {
+      spec: { hints: ["header", "container"] },
+      value: {
+        "label>": "Label"
+      }
     }
   }
-}];
+];
 
 tests.description = "'header' partial";
 


### PR DESCRIPTION
Our export to Handlebars logic is creating blocks and inverse blocks based the variable name in our templates (e.g. templateName). Those blocks are considered missing since the Handlebars language specification doesn't include them. Handlebars.NET was handling those missing blocks (i.e. "{{#templateName}}") differently than Handelbars.js was which resulted in invalid JSON documents in certain circumstances. 

Refactoring the object template generation to use {{#with templateName}} and {{#unless templateName}} resolves the issue and creates valid output from both Handlebars engines. This also has the benefit of working in cases where there would be name collisions from the template name and existing Handlebars blocks. I believe all of the following keys that are defined at the document root of this sample Lynx YAML template would cause issues without this refactor.

```
when#:
  header: When Section
unless#:
  header: Unless Section
each#:
  header: Each Section
if#:
  header: If Section
```  

This is a blocking issue on the retail search project so I'd appreciate a review and/or conversation as soon as we can.