### PR TITLE
Recognize 'follow' and 'send' as Data Properties

### DIFF
--- a/src/lib/expand-yaml.js
+++ b/src/lib/expand-yaml.js
@@ -13,10 +13,12 @@ function keyMatches(regex) {
 var excludes = [
   keyMatches(/^spec$/),
   keyMatches(/^href$/),
+  keyMatches(/^follow$/),
   keyMatches(/^src$/),
   keyMatches(/^data$/),
   keyMatches(/^action$/),
   keyMatches(/^method$/),
+  keyMatches(/^send$/),
   keyMatches(/^type$/),
   keyMatches(/^enctype$/),
   keyMatches(/^encoding$/),

--- a/test/lib/expand-yaml.js
+++ b/test/lib/expand-yaml.js
@@ -373,10 +373,12 @@ var tests = [{
 
 var reserveKeywords = [
   "href",
+  "follow",
   "src",
   "data",
   "action",
   "method",
+  "send",
   "type",
   "enctype",
   "encoding",


### PR DESCRIPTION
Both `follow` and `send` have been converted from spec properties
to data properties on link and submit controls. This change
turns off value/spec expansion for both.