### PR TITLE
Logging and run control

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "handlebars": "^4.0.5",
     "isstream": "^0.1.2",
     "json-lint": "^0.1.0",
+    "logatim": "^0.9.0",
     "md5": "^2.2.1",
     "mime": "^1.3.4",
     "stream-from-array": "^1.0.0",

--- a/src/cli/common.js
+++ b/src/cli/common.js
@@ -54,6 +54,7 @@ function applyRunControlToOptions(rc, options) {
   }
   let rcOptions = {};
   if (rc.inferInverseSections !== undefined) rcOptions.infer = rc.inferInverseSections;
+  if (rc.root) rcOptions.root = rc.root;
   if (rc.log && rc.log.level) rcOptions.log = rc.log.level;
   if (rc.spec) rcOptions.spec = rc.spec;
 

--- a/src/cli/common.js
+++ b/src/cli/common.js
@@ -49,14 +49,14 @@ function processRunControl(options) {
 }
 
 function applyRunControlToOptions(rc, options) {
-  function setIfNotPresent(key, value) { //cli arguments win over run control values
+  function setIfNotPresent(key, value) { //arguments already set win over run control values
+    if (value === null) return;
     if (options[key] === undefined) options[key] = value;
   }
   let rcOptions = {};
-  if (rc.inferInverseSections !== undefined) rcOptions.infer = rc.inferInverseSections;
-  if (rc.root) rcOptions.root = rc.root;
-  if (rc.log && rc.log.level) rcOptions.log = rc.log.level;
-  if (rc.spec) rcOptions.spec = rc.spec;
+  ["root", "log", "spec"].forEach(key => {
+    if (rc[key] !== undefined) rcOptions[key] = rc[key];
+  });
 
   //based on command (start or export) apply run control settings if they exist
   let command = options._[0];
@@ -67,6 +67,7 @@ function applyRunControlToOptions(rc, options) {
     });
   }
 
+  if (command === "start" && rcOptions.spec) delete rcOptions.spec; //spec doesn't apply to 'start'
   Object.keys(rcOptions).forEach(key => setIfNotPresent(key, rcOptions[key]));
 }
 
@@ -93,7 +94,7 @@ function normalizeRoot(options) {
     roots = types.isArray(options.root) ? options.root : [options.root];
   }
 
-  options.root = options.r = roots;
+  options.root = roots;
 }
 
 module.exports = exports = handleOptions;

--- a/src/cli/common.js
+++ b/src/cli/common.js
@@ -3,13 +3,22 @@
 const lynxDocs = require("../index");
 const path = require("path");
 const types = require("../types");
+const log = require("logatim");
 
 function handleOptions(options) {
   processConfig(options.config);
   normalizeRoot(options);
   normalizeSpecHandling(options);
+  normalizeLogging(options);
 
-  if (options.log) console.log("Options\n=======\n", options);
+  log.blue.debug("Options\n=======");
+  log.debug(JSON.stringify(options, null, 2));
+}
+
+function normalizeLogging(options) {
+  if (!options.log && process.env.LOG_LEVEL) options.log = process.env.LOG_LEVEL;
+  if (!types.isString(options.log)) options.log = "error";
+  log.setLevel(options.log);
 }
 
 function normalizeSpecHandling(options) {

--- a/src/cli/export.js
+++ b/src/cli/export.js
@@ -8,7 +8,7 @@ const getRealmMetadata = require("../lib/metadata-realm");
 
 function buildCommand(yargs) {
   return yargs
-    .usage("$0 export [--root OR root..] [--output] [--format] [--config]")
+    .usage("$0 export [--root OR root..] [--output] [--format] [--config] [--infer] [--log]")
     .option("root", {
       alias: "r",
       describe: "Root folder(s) for the web site",
@@ -27,6 +27,11 @@ function buildCommand(yargs) {
       alias: "f",
       describe: "The format to export to",
       default: "handlebars"
+    })
+    .option("log", {
+      alias: "l",
+      describe: "Set console logging level (error|warn|info|debug|trace)",
+      default: false
     })
     .option("config", {
       alias: "c",

--- a/src/cli/export.js
+++ b/src/cli/export.js
@@ -11,31 +11,22 @@ function buildCommand(yargs) {
     .usage("$0 export [--root OR root..] [--output] [--format] [--config] [--infer] [--log]")
     .option("root", {
       alias: "r",
-      describe: "Root folder(s) for the web site",
-      default: "."
+      describe: "Root folder(s) for the web site. [default '.']"
     })
     .option("output", {
       alias: "o",
-      describe: "Output folder or stream",
-      default: "stdout"
+      describe: "Output folder or stream. [default 'stdout']"
     })
     .option("infer", {
-      describe: "Infer section tokens when inverse is not supplied in template",
-      default: false
+      describe: "Infer section tokens when inverse is not supplied in template. [default false]"
     })
     .option("format", {
       alias: "f",
-      describe: "The format to export to",
-      default: "handlebars"
+      describe: "The format to export to. [default 'handlebars']"
     })
     .option("log", {
       alias: "l",
-      describe: "Set console logging level (error|warn|info|debug|trace)",
-      default: false
-    })
-    .option("config", {
-      alias: "c",
-      describe: "External configuration file to require"
+      describe: "Set console logging level (error|warn|info|debug|trace). [default 'error']"
     })
     .example("$0 export -r src -o views -f handlebars")
     .example("$0 export -r src")

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const yargs = require("yargs");
+const log = require("logatim");
 
 yargs
   .command(require("./export"))
@@ -12,8 +13,8 @@ yargs
   .example("$0 export -r src -o views")
   .example("$0 start -r src")
   .fail(function (msg, err, yargs) {
-    console.error(err || msg);
-    console.log("\nUse 'lynx-docs --help' for usage information");
+    log.red.bold.error(err || msg);
+    log.yellow.error("\nUse 'lynx-docs --help' for usage information");
     process.exit(1);
   })
   .argv;

--- a/src/cli/start.js
+++ b/src/cli/start.js
@@ -4,7 +4,7 @@ const commonCli = require("./common");
 
 function buildCommand(yargs) {
   return yargs
-    .usage("$0 start [--root OR root..] [--config] [--port]")
+    .usage("$0 start [--root OR root..] [--config] [--port] [--infer] [--log]")
     .option("port", {
       alias: "p",
       describe: "Port to listen on",
@@ -17,6 +17,11 @@ function buildCommand(yargs) {
     })
     .option("infer", {
       describe: "Infer section tokens when inverse is not supplied in template",
+      default: false
+    })
+    .option("log", {
+      alias: "l",
+      describe: "Set console logging level (error|warn|info|debug|trace)",
       default: false
     })
     .option("config", {

--- a/src/cli/start.js
+++ b/src/cli/start.js
@@ -7,26 +7,18 @@ function buildCommand(yargs) {
     .usage("$0 start [--root OR root..] [--config] [--port] [--infer] [--log]")
     .option("port", {
       alias: "p",
-      describe: "Port to listen on",
-      default: 3000
+      describe: "Port to listen on. [default 3000]"
     })
     .option("root", {
       alias: "r",
-      describe: "Root folder(s) for the web site",
-      default: "."
+      describe: "Root folder(s) for the web site. [default '.']"
     })
     .option("infer", {
-      describe: "Infer section tokens when inverse is not supplied in template",
-      default: false
+      describe: "Infer section tokens when inverse is not supplied in template. [default false]"
     })
     .option("log", {
       alias: "l",
-      describe: "Set console logging level (error|warn|info|debug|trace)",
-      default: false
-    })
-    .option("config", {
-      alias: "c",
-      describe: "External configuration file to require"
+      describe: "Set console logging level (error|warn|info|debug|trace). [default 'error']"
     })
     .example("$0 start -r src")
     .example("$0 start -p 8080")

--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,0 @@
-"use strict";
-
-//TODO: Remove module since all lynxy stuff is supposed to be handled by partials?
-
-const url = require("url");
-
-module.exports = exports = function (lynxDocs) {};

--- a/src/lib/export/process-template.js
+++ b/src/lib/export/process-template.js
@@ -5,6 +5,7 @@ const types = require("../../types");
 const parseYaml = require("../parse-yaml");
 const jsonTemplates = require("../json-templates");
 const lynxExport = require("./lynx");
+const log = require("logatim");
 
 function getTemplate(pathOrTemplate) {
   if (types.isObject(pathOrTemplate) || types.isArray(pathOrTemplate)) return pathOrTemplate;
@@ -24,24 +25,23 @@ function addRealmToTemplate(realm, template) {
   if (realm && !template.realm) template.realm = realm;
 }
 
-function log(header, value) {
-  console.log(header);
-  console.log(JSON.stringify(value), "\n");
+function logInfo(header, value) {
+  log.blue.debug("# " + header + " #");
+  log.debug(JSON.stringify(value));
 }
 
 function processTemplate(pathOrTemplate, options, createFile) {
-  let template = getTemplate(pathOrTemplate);
-  //if (options.log) log("### Template Options", options);
+  logInfo("Processing Template", pathOrTemplate);
 
-  if (options.log) log("### Template Source", template);
+  let template = getTemplate(pathOrTemplate);
+  logInfo("Template Object", template);
 
   template = jsonTemplates.expandTokens(template, options.inferInverse);
-  if (options.log) log("### Tokens Expanded", template);
+  logInfo("Tokens Expanded", template);
 
   let templatePath = types.isString(pathOrTemplate) ? pathOrTemplate : null;
   template = jsonTemplates.partials.expand(template, jsonTemplates.partials.resolve, templatePath, options.inferInverse);
-
-  if (options.log) log("### Partials Processed", template);
+  logInfo("Partials Processed", template);
 
   if (options && options.realm) {
     addRealmToTemplate(options.realm.realm, template);
@@ -52,10 +52,10 @@ function processTemplate(pathOrTemplate, options, createFile) {
 
   if (options.spec) {
     template = lynxExport.flatten(template);
-    if (options.log) log("### Flattened", template);
-    template = lynxExport.extractSpecs(template, createFile);
-    if (options.log) log("### Spec extracted", template);
+    logInfo("Flattened", template);
 
+    template = lynxExport.extractSpecs(template, createFile);
+    logInfo("Spec extracted", template);
   }
 
   return template;

--- a/src/lib/export/process-template.js
+++ b/src/lib/export/process-template.js
@@ -25,23 +25,23 @@ function addRealmToTemplate(realm, template) {
   if (realm && !template.realm) template.realm = realm;
 }
 
-function logInfo(header, value) {
+function logDebug(header, value) {
   log.blue.debug("# " + header + " #");
   log.debug(JSON.stringify(value));
 }
 
 function processTemplate(pathOrTemplate, options, createFile) {
-  logInfo("Processing Template", pathOrTemplate);
+  logDebug("Processing Template", pathOrTemplate);
 
   let template = getTemplate(pathOrTemplate);
-  logInfo("Template Object", template);
+  logDebug("Template Object", template);
 
   template = jsonTemplates.expandTokens(template, options.inferInverse);
-  logInfo("Tokens Expanded", template);
+  logDebug("Tokens Expanded", template);
 
   let templatePath = types.isString(pathOrTemplate) ? pathOrTemplate : null;
   template = jsonTemplates.partials.expand(template, jsonTemplates.partials.resolve, templatePath, options.inferInverse);
-  logInfo("Partials Processed", template);
+  logDebug("Partials Processed", template);
 
   if (options && options.realm) {
     addRealmToTemplate(options.realm.realm, template);
@@ -52,10 +52,10 @@ function processTemplate(pathOrTemplate, options, createFile) {
 
   if (options.spec) {
     template = lynxExport.flatten(template);
-    logInfo("Flattened", template);
+    logDebug("Flattened", template);
 
     template = lynxExport.extractSpecs(template, createFile);
-    logInfo("Spec extracted", template);
+    logDebug("Spec extracted", template);
   }
 
   return template;

--- a/src/lib/json-templates/partials/expand.js
+++ b/src/lib/json-templates/partials/expand.js
@@ -40,7 +40,6 @@ function expandPartials(template, resolvePartial, templatePath, inferInverseToke
       let metas = keys.map(templateKey.parse);
       let partialMetas = metas.filter(meta => !!meta.partial);
       if (partialMetas.length === 0) return;
-      //console.log("expanding", partialMetas.map(m => m.source).join());
       partialMetas.forEach(processPartialMeta);
       this.update(result);
       keys = types.isObject(result) && Object.keys(result);

--- a/src/lib/metadata-realm.js
+++ b/src/lib/metadata-realm.js
@@ -6,6 +6,7 @@ const url = require("url");
 const mime = require("mime");
 const types = require("../types");
 const parseYaml = require("./parse-yaml");
+const log = require("logatim");
 
 function getRealms(roots, realm) {
   var realms = [];
@@ -103,7 +104,7 @@ function getMetaForFolder(folder) {
 
   var meta = parseYaml(fs.readFileSync(pathToMeta));
   if (!meta) {
-    console.log("Empty metadata file was ignored: '" + pathToMeta + "'");
+    log.warn("Empty metadata file was ignored: '" + pathToMeta + "'");
     return [];
   }
 

--- a/src/server/get-realms.js
+++ b/src/server/get-realms.js
@@ -4,6 +4,7 @@ const url = require("url");
 const chokidar = require("chokidar");
 const getRealmMetadata = require("../lib/metadata-realm");
 const titleCase = require("to-title-case");
+const log = require("logatim");
 
 function getPathSegments(realmURI) {
   return url.parse(realmURI).pathname.split("/").filter(segment => segment !== "");
@@ -11,8 +12,8 @@ function getPathSegments(realmURI) {
 
 function isChildOfRealm(parentRealm) {
   return function (otherRealm) {
-    if(otherRealm.realm === parentRealm.realm) return false;
-    if(otherRealm.realm.indexOf(parentRealm.realm) === -1) return false;
+    if (otherRealm.realm === parentRealm.realm) return false;
+    if (otherRealm.realm.indexOf(parentRealm.realm) === -1) return false;
     return getPathSegments(otherRealm.realm).length -
       getPathSegments(parentRealm.realm).length === 1;
   };
@@ -20,8 +21,8 @@ function isChildOfRealm(parentRealm) {
 
 function expandVariant(realm, variant) {
   variant.title = variant.title || titleCase(variant.name);
-  if(!variant.url) variant.url = realm.url + "?variant=" + encodeURIComponent(variant.name);
-  if(!variant.handlebarsUrl) variant.handlebarsUrl = variant.url + "&format=handlebars";
+  if (!variant.url) variant.url = realm.url + "?variant=" + encodeURIComponent(variant.name);
+  if (!variant.handlebarsUrl) variant.handlebarsUrl = variant.url + "&format=handlebars";
 }
 
 function expandTemplate(realm, template) {
@@ -29,11 +30,11 @@ function expandTemplate(realm, template) {
   return {
     path: template,
     url: realm.url + "?template=" + encodeURIComponent(template)
-  }
+  };
 }
 
 function reloadRealms(target, options) {
-  if(options.log) console.log("Loading realm information.");
+  log.blue.info("Loading realm information.");
   var realms = getRealmMetadata(options.root);
 
   realms.forEach(realm => {
@@ -56,7 +57,7 @@ function getRealms(options) {
     return function () {
       reloadRealms(realms, options);
       watcher.on("all", function (event, path) {
-        if(options.log) console.log(event, path, "Reloading realm information.");
+        log.blue.info(event, path, "Reloading realm information.");
         reloadRealms(realms, options);
       });
     };

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -7,6 +7,7 @@ const serveStatic = require("./serve-static");
 const serveRealm = require("./serve-realm");
 const searchMeta = require("./meta/search-meta");
 const serveMeta = require("./meta/serve-meta");
+const log = require("logatim");
 
 function serveNotFound(req, res) {
   res.writeHead(404, { "Content-Type": "text/plain" });
@@ -17,8 +18,8 @@ function serveNotFound(req, res) {
 function serveError(req, res) {
   res.writeHead(500, { "Content-Type": "text/plain" });
   res.write("500 Server Error");
-  if(req.error) {
-    if(req.error.stack) res.write("\n\n" + req.error.stack);
+  if (req.error) {
+    if (req.error.stack) res.write("\n\n" + req.error.stack);
     else {
       res.write("\n\n".concat(req.error.message));
       res.write("\n\nError object details:\n".concat(JSON.stringify(req.error, null, 2)));
@@ -50,7 +51,7 @@ function startServer(options) {
   function addErrorHandler(req, res, next) {
     try {
       next();
-    } catch(e) {
+    } catch (e) {
       req.error = e;
       serveError(req, res);
     }
@@ -67,7 +68,7 @@ function startServer(options) {
 
   var handler = handlers.reverse().reduce(reduction, serveNotFound);
   var server = http.createServer(handler).listen(port);
-  console.log("Lynx Docs server is running at http://localhost:" + port);
+  console.log(log.green("Lynx Docs server is running at http://localhost:" + port).raw());
 
   return server;
 }

--- a/src/server/serve-static.js
+++ b/src/server/serve-static.js
@@ -2,17 +2,18 @@ const url = require("url");
 const path = require("path");
 const fs = require("fs");
 const mime = require("mime");
+const log = require("logatim");
 
 mime.define({
   "application/lynx+json": ["lnx"],
-  "application/lynx-spec+json": ["lnxs"]  
+  "application/lynx-spec+json": ["lnxs"]
 });
 
 function createServeStatic(options) {
   function serveFile(req, res, next) {
     function onFileContents(err, contents) {
       if (err) {
-        if(options.log) console.log(err);
+        log.error(err);
         return next();
       }
 
@@ -23,7 +24,7 @@ function createServeStatic(options) {
 
     function onFileStat(err, stat) {
       if (err) {
-        if(options.log) console.log(err);
+        log.error(err);
         return next();
       }
 
@@ -40,11 +41,11 @@ function createServeStatic(options) {
     var relativePathToFile = "." + url.parse(req.url).pathname;
     if (!path.extname(relativePathToFile)) return next();
 
-    var pathsToFile = options.root.map(function(root) {
+    var pathsToFile = options.root.map(function (root) {
       return path.resolve(root, relativePathToFile);
     });
 
-    var pathToFile = pathsToFile.find(function(p) {
+    var pathToFile = pathsToFile.find(function (p) {
       return fs.existsSync(p);
     });
 

--- a/test/cli/common.js
+++ b/test/cli/common.js
@@ -1,13 +1,75 @@
 "use strict";
 
-var chai = require("chai");
-var should = chai.should();
-var expect = chai.expect;
-var commonCli = require("../../src/cli/common");
+const fs = require("fs");
+const chai = require("chai");
+const expect = chai.expect;
+const sinon = require("sinon");
+const log = require("logatim");
+const yaml = require("yamljs");
+
+const commonCli = require("../../src/cli/common");
 
 describe("common cli module", function () {
+  describe("when applying defaults", function () {
+    let tests = [{
+        description: "when no values provided by cli for export",
+        should: "should apply defaults",
+        input: { _: ["export"] },
+        expected: { root: ["."], log: "error", infer: false, output: "stdout", format: "handlebars" }
+      },
+      {
+        description: "when no values provided by cli for start",
+        should: "should apply defaults",
+        input: { _: ["start"] },
+        expected: { root: ["."], log: "error", infer: false, port: 3000 }
+      },
+      {
+        description: "when values provided environment for export",
+        should: "should not override values from environment",
+        before: function () { process.env.LOG_LEVEL = "warn"; },
+        after: function () { delete process.env.LOG_LEVEL; },
+        input: { _: ["export"] },
+        expected: { root: ["."], log: "warn", infer: false, output: "stdout", format: "handlebars" }
+      },
+      {
+        description: "when values provided environment for start",
+        should: "should not override values from environment",
+        before: function () { process.env.LOG_LEVEL = "warn"; },
+        after: function () { delete process.env.LOG_LEVEL; },
+        input: { _: ["start"] },
+        expected: { root: ["."], log: "warn", infer: false, port: 3000 }
+      },
+      {
+        description: "when values provided run control for export",
+        should: "should not override values from run control",
+        before: function () {
+          let rc = { log: { level: "info" } };
+          sinon.stub(fs, "existsSync").returns(true);
+          sinon.stub(fs, "readFileSync").returns(yaml.stringify(rc));
+        },
+        after: function () {
+          fs.existsSync.restore();
+          fs.readFileSync.restore();
+        },
+        input: { _: ["export"] },
+        expected: { root: ["."], log: "info", infer: false, output: "stdout", format: "handlebars" }
+      }
+    ];
+
+    function runner(test) {
+      if (test.before) test.before();
+      commonCli(test.input);
+      if (test.after) test.after();
+      Object.keys(test.expected).forEach(key => {
+        expect(test.expected[key]).to.deep.equal(test.input[key]);
+      });
+    }
+
+    runTests(tests, runner);
+  });
+
   describe("when normalizing cli root value", function () {
-    var tests = [{
+    let tests = [{
         description: "when variadic arguments and default root",
         should: "should use variadic arugments as root values",
         input: { _: ["export", "one", "two"], root: "." },
@@ -36,7 +98,7 @@ describe("common cli module", function () {
 
   });
   describe("when normalizing cli spec values", function () {
-    var tests = [{
+    let tests = [{
         description: "when spec is not defined",
         should: "should not change options",
         input: { _: ["export"], spec: undefined },
@@ -44,25 +106,25 @@ describe("common cli module", function () {
       },
       {
         description: "when spec is true",
-        should: "should set flatten true and default spec parameters",
+        should: "should default spec parameters",
         input: { _: ["export"], spec: true },
         expected: { spec: { dir: ".", url: "/" } }
       },
       {
         description: "when spec.dir is set and spec.url is not",
-        should: "should set flatten true and default url parameter",
+        should: "should default url parameter",
         input: { _: ["export"], spec: { dir: "test" } },
         expected: { spec: { dir: "test", url: "/" } }
       },
       {
         description: "when spec.url is set and spec.dir is not",
-        should: "should set flatten true and default dir parameter",
+        should: "should default dir parameter",
         input: { _: ["export"], spec: { url: "/test/" } },
         expected: { spec: { dir: ".", url: "/test/" } }
       },
       {
         description: "when spec.url and spec.dir is set",
-        should: "should set flatten true and use parameter values",
+        should: "should use parameter values",
         input: { _: ["export"], spec: { url: "/test/", dir: "test" } },
         expected: { spec: { dir: "test", url: "/test/" } }
       }
@@ -70,8 +132,138 @@ describe("common cli module", function () {
 
     function runner(test) {
       commonCli(test.input);
-      expect(test.input.flatten).to.deep.equal(test.expected.flatten);
       expect(test.input.spec).to.deep.equal(test.expected.spec);
+    }
+
+    runTests(tests, runner);
+  });
+
+  describe("when normalizing logging", function () {
+    let tests = [{
+        description: "when no logging set",
+        should: "should set logging level to 'error'",
+        input: { _: ["export"] },
+        expected: { log: "error" }
+      },
+      {
+        description: "when logging switch set with no value",
+        should: "should set logging level to 'error'",
+        input: { _: ["export"], log: true },
+        expected: { log: "error" }
+      },
+      {
+        description: "when logging switch set with 'false' value",
+        should: "should set logging level to 'error'",
+        input: { _: ["export"], log: false },
+        expected: { log: "error" }
+      },
+      {
+        description: "when logging switch set with 'ward' value",
+        should: "should set logging level to 'warn'",
+        input: { _: ["export"], log: "warn" },
+        expected: { log: "warn" }
+      },
+      {
+        description: "when process.env.LOG_LEVEL and no logging switch set",
+        should: "should set logging level to process.env.LOG_LEVEL value",
+        before: function () { process.env.LOG_LEVEL = "warn"; },
+        after: function () { delete process.env.LOG_LEVEL; },
+        input: { _: ["export"] },
+        expected: { log: "warn" }
+      },
+      {
+        description: "when process.env.LOG_LEVEL and logging switch set",
+        should: "should set logging level to switch value",
+        before: function () { process.env.LOG_LEVEL = "error"; },
+        after: function () { delete process.env.LOG_LEVEL; },
+        input: { _: ["export"], log: "warn" },
+        expected: { log: "warn" }
+      }
+    ];
+
+    function runner(test) {
+      if (test.before) test.before();
+      commonCli(test.input);
+      if (test.after) test.after();
+      expect(test.input.log).to.equal(test.expected.log);
+      expect(log.getLevel()).to.equal(test.expected.log.toUpperCase());
+    }
+
+    runTests(tests, runner);
+  });
+
+  describe("when processing run control file", function () {
+    let tests = [{
+        description: "when no run control file present",
+        should: "should not set any options",
+        input: { _: ["export"] },
+        expected: { _: ["export"], infer: false, log: "error" }
+      },
+      {
+        description: "when run control file present",
+        should: "should set options from run control",
+        runControl: { inferInverseSections: true, log: { level: "warn" }, spec: true },
+        input: { _: ["export"] },
+        expected: { _: ["export"], infer: true, log: "warn", spec: { dir: ".", url: "/" } }
+      },
+      {
+        description: "when run control file present with spec values",
+        should: "should set options from run control",
+        runControl: { spec: { dir: "specs", url: "/specs/" } },
+        input: { _: ["export"] },
+        expected: { _: ["export"], spec: { dir: "specs", url: "/specs/" } }
+      },
+      {
+        description: "when run control file present with export values",
+        should: "should set options from run control",
+        runControl: { log: { level: "warn" }, export: { root: "foo", output: "bar", format: "baz" } },
+        input: { _: ["export"] },
+        expected: { _: ["export"], log: "warn", root: ["foo"], output: "bar", format: "baz" }
+      },
+      {
+        description: "when run control file present with start values",
+        should: "should set options from run control",
+        runControl: { log: { level: "warn" }, start: { root: "foo", port: 9000 } },
+        input: { _: ["start"] },
+        expected: { _: ["start"], log: "warn", root: ["foo"], port: 9000 }
+      },
+      {
+        description: "when run control file present with export values and overrides",
+        should: "should set options from run control and override values from export",
+        runControl: { log: { level: "warn" }, spec: true, export: { root: "foo", output: "bar", format: "baz", log: "info", spec: { dir: "specs", url: "/specs/" } } },
+        input: { _: ["export"] },
+        expected: { _: ["export"], log: "info", root: ["foo"], output: "bar", format: "baz", spec: { dir: "specs", url: "/specs/" } }
+      },
+      {
+        description: "when run control file present with start values and overrides",
+        should: "should set options from run control and override values from start",
+        runControl: { log: { level: "warn" }, start: { root: "foo", port: 9000, log: "info" } },
+        input: { _: ["start"] },
+        expected: { _: ["start"], log: "info", root: ["foo"], port: 9000 }
+      },
+      {
+        description: "when run control file and cli switches present",
+        should: "should set options from cli switches",
+        runControl: { log: { level: "warn" }, export: { root: "foo", output: "bar", format: "baz", log: "info", spec: { dir: "specs", url: "/specs/" } } },
+        input: { _: ["export"], log: "error", root: ["no foo"], output: "no bar", format: "no baz", spec: { dir: "no-specs", url: "/no-specs/" } },
+        expected: { _: ["export"], log: "error", root: ["no foo"], output: "no bar", format: "no baz", spec: { dir: "no-specs", url: "/no-specs/" } }
+      },
+
+    ];
+
+    function runner(test) {
+      if (test.runControl) {
+        sinon.stub(fs, "existsSync").returns(true);
+        sinon.stub(fs, "readFileSync").returns(yaml.stringify(test.runControl));
+      } else sinon.stub(fs, "existsSync").returns(false);
+
+      commonCli(test.input);
+      fs.existsSync.restore();
+      if (fs.readFileSync.restore) fs.readFileSync.restore();
+
+      Object.keys(test.expected).forEach(key => {
+        expect(test.expected[key]).to.deep.equal(test.input[key]);
+      });
     }
 
     runTests(tests, runner);


### PR DESCRIPTION
These changes provide a consistent logging mechanisms with the ability to set logging level on the command line, with an environment variable, or in a run control file (.lynxdocsrc).

The run control processing is part of this change as well. Here is my proposal for the run control file with comments denoting the purpose of the keys. The format of the file is YAML. This is just a start for a conversation. Please comment and improve.

.lynxdocsrc format
==================
```
root: #path string or array of path strings
log: # using level key in case we want to introduce other logging dimensions
  level: # error|warn|info|debug|trace
export:
  root: # overrides root at rc root for export.
  output: # output directory for templates
  format: # output template format
  log: # overrides log.level at rc root for export.
  spec: # overrides spec at rc root for export.
  infer: # overrides inferInverseSections at rc root for export.
start:
  root: # overrides root at rc root.
  port: # port to listen for requests on
  log: # overrides log.level at rc root for start.
  infer: # overrides inferInverseSections at rc root for start.
spec:
  dir: # directory to place specs in. If relative value, relative to process.cwd()
  url: # base uri to use when generating spec urls
inferInverseSections: # value controlling whether null inverse sections are generated if absent
```