### PR TITLE
Add --flatten CLI parameter

### DIFF
--- a/src/cli/common.js
+++ b/src/cli/common.js
@@ -81,6 +81,8 @@ function normalizeSpecHandling(options) {
   }
   if (options.spec === undefined) return;
 
+  options.flatten = true; //infer flattening when extracting specs
+
   if (!options.spec.dir) options.spec.dir = ".";
   if (!options.spec.url) options.spec.url = "/";
 }

--- a/src/cli/common.js
+++ b/src/cli/common.js
@@ -21,6 +21,7 @@ function handleOptions(options) {
 function applyDefaults(options) {
   if (options.root === undefined) options.root = ".";
   if (options.log === undefined) options.log = "error";
+  if (options.flatten === undefined) options.flatten = false;
   let command = options._[0];
   if (command.toLowerCase() === "start") {
     if (options.port === undefined) options.port = 3000;
@@ -52,7 +53,7 @@ function applyRunControlToOptions(rc, options) {
     if (options[key] === undefined) options[key] = value;
   }
   let rcOptions = {};
-  ["root", "log", "spec"].forEach(key => {
+  ["root", "log", "spec", "flatten"].forEach(key => {
     if (rc[key] !== undefined) rcOptions[key] = rc[key];
   });
 
@@ -74,9 +75,12 @@ function normalizeLogging(options) {
 }
 
 function normalizeSpecHandling(options) {
-  if (!options.spec) return;
+  if (!types.isObject(options.spec)) {
+    if (options.spec === "false" || options.spec === false) options.spec = undefined;
+    if (options.spec) options.spec = {}; //overwrite existing non object value with empty object
+  }
+  if (options.spec === undefined) return;
 
-  if (options.spec === true) options.spec = {};
   if (!options.spec.dir) options.spec.dir = ".";
   if (!options.spec.url) options.spec.url = "/";
 }

--- a/src/cli/start.js
+++ b/src/cli/start.js
@@ -18,6 +18,10 @@ function buildCommand(yargs) {
       alias: "l",
       describe: "Set console logging level (error|warn|info|debug|trace). [default 'error']"
     })
+    .option("flatten", {
+      describe: "Move spec object to parent spec object if possible. [default: false]",
+      boolean: true
+    })
     .option("spec.dir", {
       describe: "The directory to write files representing the spec object(s) in the template that can be extracted"
     })

--- a/src/lib/export/lynx/extract-specs.js
+++ b/src/lib/export/lynx/extract-specs.js
@@ -8,16 +8,6 @@ const exportLynx = require("./index");
 const types = require("../../../types");
 const templateKey = require("../../json-templates/template-key");
 
-function containsDynamicContent(value) {
-  let dynamicNodes = traverse(value).reduce(function (acc, jsValue) {
-    let meta = this.key && templateKey.parse(this.key);
-    if (meta && meta.binding) acc.push(jsValue);
-    if (types.isString(jsValue) && jsValue.indexOf("{{") > -1) acc.push(jsValue);
-    return acc;
-  }, []);
-  return dynamicNodes.length > 0;
-}
-
 function extractSpecs(template, options, createFile) {
   if (!types.isObject(options) || !types.isObject(options.spec) || !types.isString(options.spec.url) || !types.isString(options.spec.dir)) throw Error("Options must have a spec.url and spec.dir value in order to correctly write spec content and spec urls.");
 
@@ -25,7 +15,7 @@ function extractSpecs(template, options, createFile) {
 
   return traverse(template).map(function (jsValue) {
     if (exportLynx.isLynxValue(jsValue)) {
-      if (containsDynamicContent(jsValue.spec)) return;
+      if (exportLynx.containsDynamicContent(jsValue.spec)) return;
       let specContent = JSON.stringify(jsValue.spec);
       let specName = md5(specContent) + ".lnxs";
       jsValue.spec = url.resolve(options.spec.url, specName);

--- a/src/lib/export/lynx/flatten.js
+++ b/src/lib/export/lynx/flatten.js
@@ -8,7 +8,7 @@ function condenseValue(jsValue, updateValue) {
     if (types.isObject(jsValue.value)) {
       var dynamicValue = Object.keys(jsValue.value)
         .map(templateKey.parse)
-        .every(meta => meta.binding && templateKey.sectionTokens.includes(meta.binding.token));
+        .every(meta => meta.binding && (templateKey.sectionTokens.includes(meta.binding.token) || templateKey.simpleTokens.includes(meta.binding.token)));
       if (dynamicValue) return; //if the value is dynamic, then we need to keep the value key
 
       Object.assign(jsValue, jsValue.value);
@@ -25,6 +25,7 @@ function moveChildrenSpecToParent(jsValue) {
 
   accumulated.forEach(child => {
     moveChildrenSpecToParent(child.value);
+    if (exportLynx.containsDynamicContent(child.value.spec)) return;
     let childSpec = specChildren && specChildren.find(item => item.name === child.meta.name);
     if (childSpec) {
       Object.assign(childSpec, child.value.spec);

--- a/src/lib/export/lynx/index.js
+++ b/src/lib/export/lynx/index.js
@@ -1,3 +1,4 @@
+const traverse = require("traverse");
 const templateKey = require("../../json-templates/template-key");
 const types = require("../../../types");
 const specKey = "spec";
@@ -88,12 +89,23 @@ function isLynxOrResultsInLynx(jsValue) {
   return exports.isLynxValue(jsValue) || exports.resultsInLynxNode(jsValue);
 }
 
+function containsDynamicContent(value) {
+  let dynamicNodes = traverse(value).reduce(function (acc, jsValue) {
+    let meta = this.key && templateKey.parse(this.key);
+    if (meta && meta.binding) acc.push(jsValue);
+    if (types.isString(jsValue) && jsValue.indexOf("{{") > -1) acc.push(jsValue);
+    return acc;
+  }, []);
+  return dynamicNodes.length > 0;
+}
+
 exports.getLynxParentNode = getLynxParentNode;
 exports.isLynxValue = isLynxValue;
 exports.isLynxOrResultsInLynx = isLynxOrResultsInLynx;
 exports.resultsInLynxNode = resultsInLynxNode;
 exports.accumulateLynxChildren = accumulateLynxChildren;
 exports.getValuePortionOfLynxValue = getValuePortionOfLynxValue;
+exports.containsDynamicContent = containsDynamicContent;
 exports.calculateChildren = require("./calculate-children");
 exports.resolveRelativeUrls = require("./resolve-relative-urls");
 exports.flatten = require("./flatten");

--- a/src/lib/export/process-template.js
+++ b/src/lib/export/process-template.js
@@ -47,10 +47,12 @@ function processTemplate(pathOrTemplate, options, createFile) {
   template = lynxExport.calculateChildren(template);
   logDebug("Children calculated", template);
 
-  if (options.spec) {
+  if (options.flatten) {
     template = lynxExport.flatten(template);
     logDebug("Flattened", template);
+  }
 
+  if (options.spec) {
     template = lynxExport.extractSpecs(template, options, createFile);
     logDebug("Spec extracted", template);
   }

--- a/src/server/serve-static.js
+++ b/src/server/serve-static.js
@@ -18,10 +18,10 @@ function createServeStatic(options) {
       }
 
       var headers = { "Content-Type": mime.lookup(req.filename) };
-      if (options.spec.cache && path.extname(req.filename) === ".lnxs") {
+      if (options.spec && options.spec.cache && path.extname(req.filename) === ".lnxs") {
         headers["Cache-Control"] = "max-age=31536000";
       }
-      
+
       res.writeHead(200, headers);
       res.write(contents, "binary");
       res.end();

--- a/test/cli/common.js
+++ b/test/cli/common.js
@@ -10,7 +10,7 @@ const yaml = require("yamljs");
 const commonCli = require("../../src/cli/common");
 
 function defaultSettings(command) {
-  let settings = { _: [command], root: ["."], log: "error" };
+  let settings = { _: [command], root: ["."], log: "error", flatten: false };
   if (command === "export") {
     Object.assign(settings, { "output": "stdout", format: "handlebars" });
   } else {
@@ -117,6 +117,18 @@ describe("common cli module", function () {
         should: "should default spec parameters",
         input: { _: ["export"], spec: true },
         expected: { spec: { dir: ".", url: "/" } }
+      },
+      {
+        description: "when spec is false",
+        should: "should remove spec parameters",
+        input: { _: ["export"], spec: false },
+        expected: { spec: undefined }
+      },
+      {
+        description: "when spec is 'false'",
+        should: "should remove spec parameters",
+        input: { _: ["export"], spec: 'false' },
+        expected: { spec: undefined }
       },
       {
         description: "when spec.dir is set and spec.url is not",

--- a/test/cli/common.js
+++ b/test/cli/common.js
@@ -224,21 +224,21 @@ describe("common cli module", function () {
         should: "should set options from run control",
         runControl: { log: "warn", spec: true },
         input: { _: ["export"] },
-        expected: Object.assign(defaultSettings("export"), { log: "warn", spec: { dir: ".", url: "/" } })
+        expected: Object.assign(defaultSettings("export"), { log: "warn", spec: { dir: ".", url: "/" }, flatten: true })
       },
       {
         description: "when run control file present with spec values and 'export'",
         should: "should set options from run control",
         runControl: { log: "warn", spec: { dir: "specs", url: "/specs/" } },
         input: { _: ["export"] },
-        expected: Object.assign(defaultSettings("export"), { log: "warn", spec: { dir: "specs", url: "/specs/" } })
+        expected: Object.assign(defaultSettings("export"), { log: "warn", spec: { dir: "specs", url: "/specs/" }, flatten: true })
       },
       {
         description: "when run control file present with spec values and 'start'",
         should: "should set options from run control but delete 'spec'",
         runControl: { log: "warn", spec: { dir: "specs", url: "/specs/" } },
         input: { _: ["start"] },
-        expected: Object.assign(defaultSettings("start"), { log: "warn", spec: { dir: "specs", url: "/specs/" } })
+        expected: Object.assign(defaultSettings("start"), { log: "warn", spec: { dir: "specs", url: "/specs/" }, flatten: true })
       },
       {
         description: "when run control file present with export values",
@@ -259,7 +259,7 @@ describe("common cli module", function () {
         should: "should set options from run control and override values from export",
         runControl: { log: "warn", spec: true, export: { root: "foo", output: "bar", format: "baz", log: "info", spec: { dir: "specs", url: "/specs/" } } },
         input: { _: ["export"] },
-        expected: Object.assign(defaultSettings("export"), { log: "info", root: ["foo"], output: "bar", format: "baz", spec: { dir: "specs", url: "/specs/" } })
+        expected: Object.assign(defaultSettings("export"), { log: "info", root: ["foo"], output: "bar", format: "baz", spec: { dir: "specs", url: "/specs/" }, flatten: true })
       },
       {
         description: "when run control file present with start values and overrides",
@@ -273,7 +273,7 @@ describe("common cli module", function () {
         should: "should set options from cli switches",
         runControl: { log: "warn", export: { root: "foo", output: "bar", format: "baz", log: "info", spec: { dir: "specs", url: "/specs/" } } },
         input: { _: ["export"], log: "error", root: ["no foo"], output: "no bar", format: "no baz", spec: { dir: "no-specs", url: "/no-specs/" } },
-        expected: Object.assign(defaultSettings("export"), { log: "error", root: ["no foo"], output: "no bar", format: "no baz", spec: { dir: "no-specs", url: "/no-specs/" } })
+        expected: Object.assign(defaultSettings("export"), { log: "error", root: ["no foo"], output: "no bar", format: "no baz", spec: { dir: "no-specs", url: "/no-specs/" }, flatten: true })
       },
 
     ];

--- a/test/lib/export/lynx/flatten.js
+++ b/test/lib/export/lynx/flatten.js
@@ -54,6 +54,61 @@ var tests = [{
     }
   },
   {
+    description: "dynamic spec in child",
+    should: "not flatten template",
+    template: {
+      ">list": {
+        "spec.labeledBy": "label",
+        "#firstName": {
+          "label>": "First Name",
+          "firstName>line": {
+            "value<value": "",
+            "spec.input": true,
+            "spec.validation": {
+              required: {
+                "state<requiredConstraintState": "",
+                invalid: "requiredError"
+              }
+            }
+          },
+          "requiredError>text": "Required"
+        },
+        "^firstName": null
+      }
+    },
+    expected: {
+      spec: {
+        hints: ["list", "container"],
+        labeledBy: "label",
+        children: [
+          { name: "label", hints: ["label", "text"] },
+          { name: "firstName" },
+          { name: "requiredError", hints: ["text"] }
+        ]
+      },
+      value: {
+        "#firstName": {
+          label: { "": "First Name" },
+          firstName: {
+            spec: {
+              hints: ["line", "text"],
+              input: true,
+              validation: {
+                required: {
+                  state: { "<requiredConstraintState": "" },
+                  invalid: "requiredError"
+                }
+              }
+            },
+            value: { "<value": "" }
+          },
+          requiredError: { "": "Required" }
+        },
+        "^firstName": null
+      }
+    }
+  },
+  {
     description: "array container with object containers values",
     should: "not flatten template",
     template: { ">container": [{ ">container": { "message>text": "Hello" } }] },


### PR DESCRIPTION
When parameter is `true` or when switch is set, then specs are moved to their parent's spec object when possible.
Fixed issue with server test that was causing a test failure
Added ability to turn specs off with CLI switch value of `--spec false`