### PR TITLE
Inline Small Specs

### DIFF
--- a/src/lib/export/lynx/extract-specs.js
+++ b/src/lib/export/lynx/extract-specs.js
@@ -7,6 +7,7 @@ const url = require("url");
 const exportLynx = require("./index");
 const types = require("../../../types");
 const templateKey = require("../../json-templates/template-key");
+const log = require("logatim");
 
 function extractSpecs(template, options, createFile) {
   if (!types.isObject(options) || !types.isObject(options.spec) || !types.isString(options.spec.url) || !types.isString(options.spec.dir)) throw Error("Options must have a spec.url and spec.dir value in order to correctly write spec content and spec urls.");
@@ -16,7 +17,14 @@ function extractSpecs(template, options, createFile) {
   return traverse(template).map(function (jsValue) {
     if (exportLynx.isLynxValue(jsValue)) {
       if (exportLynx.containsDynamicContent(jsValue.spec)) return;
+      
       let specContent = JSON.stringify(jsValue.spec);
+      if (("size" in options.spec) && (specContent.length < options.spec.size)) {
+        log.debug(`Skipping extraction for the following spec because its size is less than ${options.spec.size} bytes:`);
+        log.debug(specContent);
+        return;
+      }
+      
       let specName = md5(specContent) + ".lnxs";
       jsValue.spec = url.resolve(options.spec.url, specName);
 


### PR DESCRIPTION
Added an option to the `spec` param to allow the user to set a `size` limit to ensure that small specs are not extracted.