### PR TITLE
Fix for issue #62

### DIFF
--- a/src/lib/export/lynx/flatten.js
+++ b/src/lib/export/lynx/flatten.js
@@ -2,7 +2,9 @@ const traverse = require("traverse");
 const types = require("../../../types");
 const exportLynx = require("./index");
 const templateKey = require("../../json-templates/template-key");
+const log = require("logatim");
 const valueKey = "value";
+const documentKeys = ["realm", "base", "focus", "context"];
 
 function shouldCondenseObject(jsValue) {
   var dynamicValue = Object.keys(jsValue.value)
@@ -10,10 +12,13 @@ function shouldCondenseObject(jsValue) {
     .every(meta => meta.binding && (templateKey.sectionTokens.includes(meta.binding.token) || templateKey.simpleTokens.includes(meta.binding.token)));
   if (dynamicValue) return false; //if the value is dynamic, then we need to keep the value key
 
-  if (exportLynx.isLynxValue(jsValue) &&
-    !exportLynx.getLynxParentNode(this) &&
-    (jsValue.value.realm || jsValue.value.base || jsValue.value.focus || jsValue.value.context)
-  ) return false;
+  if (exportLynx.isLynxValue(jsValue) && !exportLynx.getLynxParentNode(this)) {
+    var keys = documentKeys.filter(key => key in jsValue.value);
+    if (keys.length > 0) {
+      log.yellow("Unexpected document key(s) '" + keys.join("','") + "' exist in the 'value' component. Flattening disabled.").warn();
+      return false;
+    }
+  }
 
   return true;
 }

--- a/test/lib/export/lynx/flatten.js
+++ b/test/lib/export/lynx/flatten.js
@@ -29,6 +29,78 @@ var tests = [{
     }
   },
   {
+    description: "document with realm in value component",
+    should: "not flatten template",
+    template: { realm: "http://example.com/bar", ">container": { "message>text": "Hello", "realm": "http://example.com/foo/" } },
+    expected: {
+      realm: "http://example.com/bar",
+      spec: {
+        hints: ["container"],
+        children: [
+          { name: "message", hints: ["text"] }
+        ]
+      },
+      value: {
+        message: { "": "Hello" },
+        realm: "http://example.com/foo/"
+      }
+    }
+  },
+  {
+    description: "document with base in value component",
+    should: "not flatten template",
+    template: { base: "http://example.com/bar", ">container": { "message>text": "Hello", "base": "http://example.com/foo/" } },
+    expected: {
+      base: "http://example.com/bar",
+      spec: {
+        hints: ["container"],
+        children: [
+          { name: "message", hints: ["text"] }
+        ]
+      },
+      value: {
+        message: { "": "Hello" },
+        base: "http://example.com/foo/"
+      }
+    }
+  },
+  {
+    description: "document with focus in value component",
+    should: "not flatten template",
+    template: { focus: "message", ">container": { "message>text": "Hello", "focus": "foo" } },
+    expected: {
+      focus: "message",
+      spec: {
+        hints: ["container"],
+        children: [
+          { name: "message", hints: ["text"] }
+        ]
+      },
+      value: {
+        message: { "": "Hello" },
+        focus: "foo"
+      }
+    }
+  },
+  {
+    description: "document with context in value component",
+    should: "not flatten template",
+    template: { context: "http://example.com/bar", ">container": { "message>text": "Hello", "context": "http://example.com/foo/" } },
+    expected: {
+      context: "http://example.com/bar",
+      spec: {
+        hints: ["container"],
+        children: [
+          { name: "message", hints: ["text"] }
+        ]
+      },
+      value: {
+        message: { "": "Hello" },
+        context: "http://example.com/foo/"
+      }
+    }
+  },
+  {
     description: "nested object containers",
     should: "flatten template",
     template: { ">container": { "c1>container": { "message>text": "Hello" } } },


### PR DESCRIPTION
This change prevents flattening at the document level when there are document level properties in the value component of the value spec pair.