### PR TITLE
Better error content when generating lynx

### DIFF
--- a/src/lib/export/template-data.js
+++ b/src/lib/export/template-data.js
@@ -3,8 +3,6 @@ const path = require("path");
 const parseYaml = require("../parse-yaml");
 
 function readDataFile(dataFile) {
-  var parsedPath = path.parse(dataFile);
-
   function getContents() {
     return fs.readFileSync(dataFile);
   }
@@ -14,15 +12,22 @@ function readDataFile(dataFile) {
     return readDataFile(otherDataFile);
   }
 
-  if (parsedPath.ext === ".yml") return parseYaml(getContents()) || {};
-  if (parsedPath.ext === ".json") return JSON.parse(getContents().toString());
-  if (parsedPath.ext === ".js") {
-    delete require.cache[require.resolve(dataFile)];
+  try {
+    let parsedPath = path.parse(dataFile);
+    if (parsedPath.ext === ".yml") return parseYaml(getContents()) || {};
+    if (parsedPath.ext === ".json") return JSON.parse(getContents().toString());
+    if (parsedPath.ext === ".js") {
+      delete require.cache[require.resolve(dataFile)];
 
-    var generator = require(dataFile);
-    return generator(resolveDataFile);
+      let generator = require(dataFile);
+      return generator(resolveDataFile);
+    }
+  } catch (err) {
+    err.message = `Error reading data file '${dataFile}'\r\n${err.message}`;
+    throw err;
   }
-  throw new Error("Unrecognized example data file format: ", parsedPath.ext);
+
+  throw new Error("Unrecognized data file format: ", parsedPath.ext);
 }
 
 module.exports = exports = readDataFile;


### PR DESCRIPTION
Instead of throwing errors out of the lynx generation process we capture them and create a lynx document with the error information in the same realm of the document that was requested. This is to surface more meaningful error information to the user as well as keep scoped content from taking over the entire view when an error occurs.
- Generates specific content for YAML parse failures
- Generates specific content for JSON lint failures during data binding.
- Appended data file name to error message when resolving data files so that name was available in the error document.