### PR TITLE
Add Support for JavaScript Variants

### DIFF
--- a/src/server/get-realms.js
+++ b/src/server/get-realms.js
@@ -39,7 +39,7 @@ function isChildOfRealm(parentRealm) {
 function expandVariant(realm, variant) {
   variant.title = variant.title || titleCase(variant.name);
   if (!variant.url) variant.url = realm.url + "?variant=" + encodeURIComponent(variant.name);
-  if (!variant.handlebarsUrl) variant.handlebarsUrl = variant.url + "&format=handlebars";
+  if (variant.template && variant.data && !variant.handlebarsUrl) variant.handlebarsUrl = variant.url + "&format=handlebars";
 }
 
 function expandTemplate(realm, template) {

--- a/src/server/serve-realm.js
+++ b/src/server/serve-realm.js
@@ -43,10 +43,9 @@ module.exports = exports = function createRealmHandler(options) {
       res.end();
     }
     
-    function serveTemplateDataVariant(variant, includeIndexHeader) {
+    function serveTemplateDataVariant(variant) {
       res.setHeader("Content-Type", "application/lynx+json");
       res.setHeader("Cache-control", "no-cache");
-      if (includeIndexHeader) res.setHeader("X-Variant-Index", url.parse(req.url).pathname + "?variant=index");
 
       var variantOptions = Object.assign({}, options, { realm: realm });
 
@@ -68,8 +67,8 @@ module.exports = exports = function createRealmHandler(options) {
       handler(req, res, next);
     }
 
-    function serveVariant(variant, includeIndexHeader) {
-      if (variant.template && variant.data) return serveTemplateDataVariant(variant, includeIndexHeader);
+    function serveVariant(variant) {
+      if (variant.template && variant.data) return serveTemplateDataVariant(variant);
       if (variant.js) return serveJavaScriptVariant(variant);
       serveRealmIndex();
     }

--- a/src/server/serve-realm.js
+++ b/src/server/serve-realm.js
@@ -76,7 +76,7 @@ module.exports = exports = function createRealmHandler(options) {
     }
 
     function serveVariant(variant) {
-      if (variant.template && variant.data) return serveTemplateDataVariant(variant);
+      if (variant.template) return serveTemplateDataVariant(variant);
       if (variant.jsmodule) return serveJavaScriptVariant(variant);
       serveRealmIndex();
     }

--- a/src/server/serve-realm.js
+++ b/src/server/serve-realm.js
@@ -62,10 +62,7 @@ module.exports = exports = function createRealmHandler(options) {
       }
       
       var handlerFactory = require(pkg);
-      
-      if (handlerFactory.nocache) {
-        delete require.cache[require.resolve(pkg)];
-      }
+      delete require.cache[require.resolve(pkg)];
       
       var handler = handlerFactory(variant, realm);
       handler(req, res, next);


### PR DESCRIPTION
This PR adds support for javascript (JS) variants. This feature adds natural extensibility to lynx-docs by enabling users to add new variants to any realm using javascript. By being able to add a javascript variant, users will be able to more closely mimic their dynamic application server when necessary.

This feature adds a new property to the variant object: `js`. This property is mutually exclusive with the `template` and `data` properties. The value of the `js` property is a Node module string that is equivalent to the value passed to Node's `require` function with the exception that relative paths are resolved to the process's current working directory (usually the project root) rather than the calling file's path.

If the `js` property is present, lynx-docs will `require` the file or package. The file or package should return the following interface:

```
function sampleJSVariant(variant, realm) {
  return function (req, res, next) {
    // handle NodeJS request here or delegate to next()
  };
}

module.exports = exports = sampleJSVariant;
```

To register a JS variant, a user must declare the variant in a `.meta.yml` file. Since the variant and realm objects are passed to the JS variant via the `variant` and `realm` parameters, these objects may be used to pass parameters to the JS variant.

```
variants:
  - name: sample-javascript-variant
    js: ./src/sample-variant/test.js
    p1: an example string parameter
  - name: sample-npm-variant
    js: some-npm-package
```
