### PR TITLE
Remove content data/src Linter Rule

### DIFF
--- a/src/lib/export/lynx/validateDocument/content.js
+++ b/src/lib/export/lynx/validateDocument/content.js
@@ -27,7 +27,6 @@ function validateContent(value) {
   if (types.isNull(value)) return [];
   if (!types.isObject(value)) return ["'content' value must be an object"];
   let errors = [];
-  if (!value.src && !value.data) errors.push("'content' value must have an 'src' or 'data' property");
   if (value.src) validateSrc(value, errors);
   if (value.data) validateData(value, errors);
   return errors;

--- a/test/lib/export/lynx/validateDocument/content.js
+++ b/test/lib/export/lynx/validateDocument/content.js
@@ -26,11 +26,6 @@ let tests = [{
     expected: ["'content' value must be an object"]
   },
   {
-    description: "'content' with neither 'data' nor 'src'",
-    should: "return errors",
-    content: {},
-    expected: ["'content' value must have an 'src' or 'data' property"]
-  }, {
     description: "'content' with 'data' and 'src'",
     should: "return errors",
     content: { src: ".", type: "text/plain", data: "Hello world" },


### PR DESCRIPTION
This rule broke an existing app where we use empty `content` objects with just a `scope` in order to create subwindow targerts.