### PR TITLE
Fix partial token processing

### DIFF
--- a/src/lib/json-templates/partials/partial-key.js
+++ b/src/lib/json-templates/partials/partial-key.js
@@ -1,26 +1,13 @@
 "use strict";
 
-const types = require("../../../types");
-const keySection = /^([@#\^><=]?[a-zA-Z0-9.\-*:\/]+[@#\^><=]?)(~{0,1})([a-zA-Z0-9.\-*:\/]+)?$/;
+const templateKey = require("../template-key");
 const wildcardCar = "*";
 
 function parse(key) {
-  // key, key~, key~key should all yield 'key'
-  if (types.isNumber(key)) return { name: key };
-  if (!types.isString(key)) throw Error("key must be a number or a string");
+  let parsed = templateKey.parse(key, true);
 
-  let parsed = { source: key };
-  let match = keySection.exec(key);
+  if (parsed.placeholder) parsed.placeholder.wildcard = parsed.placeholder.variable === wildcardCar;
 
-  if (match) {
-    parsed.name = match[1];
-    if (match[2]) {
-      parsed.wildcard = parsed.name === wildcardCar;
-      parsed.variable = parsed.wildcard ? parsed.name : match[3] || parsed.name;
-    }
-  }
-
-  if (!parsed.name) throw Error("'" + key + "' is not a valid partial key.");
   return parsed;
 }
 

--- a/src/lib/json-templates/partials/process.js
+++ b/src/lib/json-templates/partials/process.js
@@ -6,56 +6,58 @@ const partialKey = require("./partial-key");
 const types = require("../../../types");
 const emptyKey = "";
 
-function processReplacements(replacements, parameters) {
-  replacements.forEach(item => {
-    let value = item.value;
-    item.keys.forEach(partialKey => {
-      if (partialKey.wildcard) {
+function sortPlaceholders(placeholders) {
+  placeholders.sort((a, b) => { //partials with wildcard replacements need to processed last
+    if (a.keys.some(k => k.placeholder.wildcard)) return 1;
+    if (b.keys.some(k => k.placeholder.wildcard)) return -1;
+    return 0;
+  });
+  placeholders.forEach(p =>
+    p.keys.sort((a, b) => { //wildcards need to be processed last      
+      if (a.placeholder.wildcard) return 1;
+      if (b.placeholder.wildcard) return -1;
+      return 0;
+    }));
+}
+
+function processPlaceholders(placeholders, parameters) {
+  sortPlaceholders(placeholders);
+  placeholders.forEach(level => {
+    level.keys.forEach(key => {
+      let placeholder = key.placeholder;
+      if (placeholder.wildcard) {
         if (!types.isObject(parameters)) {
-          value[emptyKey] = parameters; //create value template for non-object parameters
+          level.value[emptyKey] = parameters; //create value template for non-object parameters
         } else {
           Object.keys(parameters).forEach(key => {
-            value[key] = parameters[key];
+            level.value[key] = parameters[key];
             delete parameters[key]; //consume the parameter
           });
         }
       } else {
-        if (types.isObject(parameters) && Object.keys(parameters).includes(partialKey.variable)) {
-          value[partialKey.name] = parameters[partialKey.variable];
-          delete parameters[partialKey.variable]; //consume the parameter
+        if (types.isObject(parameters) && Object.keys(parameters).includes(placeholder.variable)) {
+          level.value[key.name] = parameters[placeholder.variable];
+          delete parameters[placeholder.variable]; //consume the parameter
         } else { //didn't match in parameters so use default
-          value[partialKey.name] = value[partialKey.source];
+          level.value[key.name] = level.value[key.source];
         }
       }
-      delete value[partialKey.source]; //remove the original from the partial
+      delete level.value[key.source]; //remove the original from the partial
     });
   });
-}
-
-function getPartialKeys(sourceKeys) {
-  return sourceKeys.map(partialKey.parse)
-    .sort((a, b) => { //wildcards need to be processed last
-      if (a.wildcard) return 1;
-      if (b.wildcard) return -1;
-      return 0;
-    });
 }
 
 function processPartial(partial, parameters) {
-  let replacements = traverse(partial).reduce(function (acc, value) {
+  let placeholders = traverse(partial).reduce(function (acc, value) {
     if (!this.keys || types.isArray(value)) return acc;
-    let partialKeys = getPartialKeys(this.keys).filter(key => !!key.variable);
-    if (partialKeys.length === 0) return acc;
+    let keys = this.keys.map(partialKey.parse).filter(key => !!key.placeholder);
+    if (keys.length === 0) return acc;
 
-    acc.push({ keys: partialKeys, value: value });
+    acc.push({ keys: keys, value: value });
     return acc;
-  }, []).sort((a, b) => { //partials with wildcard replacements need to processed last
-    if (a.keys.some(k => k.wildcard)) return 1;
-    if (b.keys.some(k => k.wildcard)) return -1;
-    return 0;
-  });
+  }, []);
 
-  processReplacements(replacements, parameters);
+  processPlaceholders(placeholders, parameters);
 
   return partial;
 }

--- a/src/lib/json-templates/template-key.js
+++ b/src/lib/json-templates/template-key.js
@@ -1,26 +1,30 @@
 "use strict";
 
 const types = require("../../types");
-const keySection = /([@#\^><=]){0,1}([a-zA-Z0-9.\-~*:\/]*)/g;
+const templateKeySection = /([@#\^><=]){0,1}([a-zA-Z0-9.\-~*:\/]*)/g;
+const partialKeySection = /([@#\^><=~]){0,1}([a-zA-Z0-9.\-*:\/]*)/g;
 
-function parse(key) {
+function parse(key, partialSyntax) {
   // key, key@, key#, key^, key<, key@foo, key#foo, key^foo, key<foo, should all yield 'key'
   if (types.isNumber(key)) return { name: key };
   if (!types.isString(key)) throw Error("key must be a number or a string");
 
+  let expression = partialSyntax ? partialKeySection : templateKeySection;
   let parsed = { source: key };
   let match;
-  while ((match = keySection.exec(key)) !== null) {
+  while ((match = expression.exec(key)) !== null) {
     // This is necessary to avoid infinite loops with zero-width matches
-    if (match.index === keySection.lastIndex) keySection.lastIndex++;
+    if (match.index === expression.lastIndex) expression.lastIndex++;
 
     if (match.index === 0 && !match[1]) parsed.name = match[2]; //key name doesn't have tokens
     else {
       if (match[1]) { //if we have a template token then push the template info
         let variable = match[2] || parsed.name;
         if (!variable) throw Error("Token must have explicit variable if 'name' does not exist.");
-        if (exports.partialToken === match[1]) parsed.partial = { token: match[1], variable: variable };
-        else parsed.binding = { token: match[1], variable: variable };
+        let token = match[1];
+        if (exports.partialToken === token) parsed.partial = { token: token, variable: variable };
+        else if (exports.placeHolderToken === token) parsed.placeholder = { variable: variable };
+        else parsed.binding = { token: token, variable: variable };
       }
     }
   }
@@ -36,6 +40,7 @@ exports.positiveSectionToken = "#";
 exports.negativeSectionToken = "^";
 exports.iteratorToken = "@";
 exports.partialToken = ">";
+exports.placeHolderToken = "~";
 exports.simpleTokens = ["<", "="];
 exports.sectionTokens = ["#", "^"];
 exports.allTokens = ["<", "=", "#", "^", "@", ">"];

--- a/test/lib/json-templates/expand-tokens.js
+++ b/test/lib/json-templates/expand-tokens.js
@@ -34,6 +34,16 @@ let tests = [{
     expected: { "@foo": { ">partial": { "<bar": "Yes bar" } } }
   },
   {
+    description: "value has multiple explicit template keys (<>)",
+    template: { "foo<bar>partial": "Yes bar" },
+    expected: { "foo": { ">partial": { "<bar": "Yes bar" } } }
+  },
+  {
+    description: "value has multiple implicit template keys (<>)",
+    template: { "foo<>": "Yes bar" },
+    expected: { "foo": { ">foo": { "<foo": "Yes bar" } } }
+  },
+  {
     description: "intermediate syntax",
     template: { "foo#": "Yes foo", "foo^": "No foo" },
     expected: { foo: { "#foo": "Yes foo", "^foo": "No foo" } }

--- a/test/lib/json-templates/partials/partial-key.js
+++ b/test/lib/json-templates/partials/partial-key.js
@@ -2,7 +2,6 @@ const chai = require("chai");
 const expect = chai.expect;
 
 const partialKey = require("../../../../src/lib/json-templates/partials/partial-key");
-const templateKey = require("../../../../src/lib/json-templates/template-key");
 
 let tests = [{
     description: "key has name only",
@@ -17,72 +16,77 @@ let tests = [{
   {
     description: "key with name and variable",
     key: "foo~",
-    expected: { name: "foo", wildcard: false, variable: "foo" }
+    expected: { name: "foo", placeholder: { wildcard: false, variable: "foo" } }
   },
   {
     description: "key with name '<' binding and variable",
     key: "foo<~",
-    expected: { name: "foo<", wildcard: false, variable: "foo<" }
+    expected: { name: "foo", placeholder: { wildcard: false, variable: "foo" } }
+  },
+  {
+    description: "key with name '<' binding, partial reference, and variable",
+    key: "foo<>",
+    expected: { name: "foo" }
   },
   {
     description: "key with name '=' binding and variable",
     key: "foo=~",
-    expected: { name: "foo=", wildcard: false, variable: "foo=" }
+    expected: { name: "foo", placeholder: { wildcard: false, variable: "foo" } }
   },
   {
     description: "key with name '#' binding and variable",
     key: "foo#~",
-    expected: { name: "foo#", wildcard: false, variable: "foo#" }
+    expected: { name: "foo", placeholder: { wildcard: false, variable: "foo" } }
   },
   {
     description: "key with name '^' binding and variable",
     key: "foo^~",
-    expected: { name: "foo^", wildcard: false, variable: "foo^" }
+    expected: { name: "foo", placeholder: { wildcard: false, variable: "foo" } }
   },
   {
-    description: "key with name '>' binding and variable",
+    description: "key with name '>' partial and variable",
     key: "foo>~",
-    expected: { name: "foo>", wildcard: false, variable: "foo>" }
+    expected: { name: "foo", placeholder: { wildcard: false, variable: "foo" } }
   },
   {
     description: "key with name '<' binding and named variable",
     key: "foo<~foo",
-    expected: { name: "foo<", wildcard: false, variable: "foo" }
+    expected: { name: "foo", placeholder: { wildcard: false, variable: "foo" } }
   },
   {
     description: "key with name '=' binding and named variable",
     key: "foo=~foo",
-    expected: { name: "foo=", wildcard: false, variable: "foo" }
+    expected: { name: "foo", placeholder: { wildcard: false, variable: "foo" } }
   },
   {
     description: "key with name '#' binding and named variable",
     key: "foo#~foo",
-    expected: { name: "foo#", wildcard: false, variable: "foo" }
+    expected: { name: "foo", placeholder: { wildcard: false, variable: "foo" } }
   },
   {
     description: "key with name '^' binding and named variable",
     key: "foo^~foo",
-    expected: { name: "foo^", wildcard: false, variable: "foo" }
+    expected: { name: "foo", placeholder: { wildcard: false, variable: "foo" } }
   },
   {
-    description: "key with name '>' binding and named variable",
+    description: "key with name '>' partial and named variable",
     key: "foo>~foo",
-    expected: { name: "foo>", wildcard: false, variable: "foo" }
+    expected: { name: "foo", placeholder: { wildcard: false, variable: "foo" } }
   },
   {
     description: "key with name with dashes and variable",
     key: "foo-name~",
-    expected: { name: "foo-name", wildcard: false, variable: "foo-name" }
+    expected: { name: "foo-name", placeholder: { wildcard: false, variable: "foo-name" } }
   },
   {
     description: "key with name and named variable",
     key: "foo~foo",
-    expected: { name: "foo", wildcard: false, variable: "foo" }
+    expected: { name: "foo", placeholder: { wildcard: false, variable: "foo" } }
   },
   {
     description: "key with name with dashes and named variale with dashes",
     key: "foo-name~bar-name",
-    expected: { name: "foo-name", wildcard: false, variable: "bar-name" }
+    expected: { name: "foo-name", placeholder: { wildcard: false, variable: "bar-name" } }
   },
   {
     description: "wildcard key name only",
@@ -92,19 +96,17 @@ let tests = [{
   {
     description: "wildcard key and variable",
     key: "*~",
-    expected: { name: "*", wildcard: true, variable: "*" }
-  },
-  {
-    description: "wildcard key and named variable",
-    key: "*~foo",
-    expected: { name: "*", wildcard: true, variable: "*" }
+    expected: { name: "*", placeholder: { wildcard: true, variable: "*" } }
   }
 ];
 
 function runTest(test) {
   let result = partialKey.parse(test.key);
-  test.expected.source = test.key;
-  expect(result).to.deep.equal(test.expected);
+  if (result.placeholder || test.expected.placeholder) {
+    expect(result.placeholder).to.deep.equal(test.expected.placeholder);
+  }
+  expect(result.source).to.equal(test.key);
+  expect(result.name).to.equal(test.expected.name);
 }
 
 describe("partial key module", function () {
@@ -114,18 +116,6 @@ describe("partial key module", function () {
       tests.forEach(function (test) {
         describe("when " + test.description + " (i.e '" + test.key + "')", function () {
           it("should result in expected result", function () {
-            runTest(test);
-          });
-        });
-      });
-    });
-
-    describe("when processing keys with tokens", function () {
-      templateKey.allTokens.forEach(token => {
-        describe("when processing key with token '" + token + "'", function () {
-          it("should allow token in key name", function () {
-            let key = "test" + token;
-            let test = { key: key, expected: { name: key } };
             runTest(test);
           });
         });

--- a/test/lib/json-templates/partials/process.js
+++ b/test/lib/json-templates/partials/process.js
@@ -102,6 +102,13 @@ let tests = [{
     expected: { value: { "name<": "Your name" }, "message": "Hello" }
   },
   {
+    description: "a partial with named placeholder referencing another partial called with parameter referencing different partial",
+    should: "should replace named placeholder",
+    partial: { header: { "message~>label": "Goodbye" } },
+    parameters: { message: { ">stylized-text": "Hello" } },
+    expected: { header: { message: { ">stylized-text": "Hello" } } }
+  },
+  {
     description: "a partial with the wildcard placeholder",
     should: "should return all parameter keys and values in place of wildcard",
     partial: { value: { "*~": null } },
@@ -122,12 +129,6 @@ let tests = [{
     parameters: { "spec.visibility": "hidden", one: "one" },
     expected: { ">lynx": { "spec.hints": ["container"], "spec.visibility": "hidden", one: "one" } }
   },
-  /*
-  previous#>link:
-  label>: "←"
-  href<: ../slots/
-
-  */
   {
     description: "placeholders that are nested",
     should: "should return perform replacements and return partial",
@@ -153,15 +154,6 @@ let tests = [{
   },
 ];
 
-/*
->section:
-  spec.hints: [ "http://uncategorized/listing/item", card, section, container ]
-  symbol>lynx:
-    spec.hints: [ "http://uncategorized/listing/item/symbol", container]
-    symbol~: ●
-  ~*:
-
-*/
 function getTests() {
   let filtered = tests.filter(test => test.include === true);
   return filtered.length > 0 ? filtered : tests;

--- a/test/lib/json-templates/template-key.js
+++ b/test/lib/json-templates/template-key.js
@@ -22,6 +22,14 @@ let tests = [{
     }
   },
   {
+    description: "key with name and placeholder token as variable",
+    key: "foo<~",
+    expected: {
+      name: "foo",
+      binding: { token: "<", variable: "~" }
+    }
+  },
+  {
     description: "key with name with dashes and binding only",
     key: "foo-name#",
     expected: {
@@ -64,11 +72,20 @@ let tests = [{
     }
   },
   {
-    description: "key with name, binding, and partial",
+    description: "key with name, section binding, and partial",
     key: "foo#>",
     expected: {
       name: "foo",
       binding: { token: "#", variable: "foo" },
+      partial: { token: ">", variable: "foo" }
+    }
+  },
+  {
+    description: "key with name, value binding, and partial",
+    key: "foo<>",
+    expected: {
+      name: "foo",
+      binding: { token: "<", variable: "foo" },
       partial: { token: ">", variable: "foo" }
     }
   },

--- a/test/lib/partials/link.js
+++ b/test/lib/partials/link.js
@@ -8,12 +8,21 @@ var tests = [{
     }
   },
   {
-    description: "when no type",
+    description: "when no type and href",
     should: "add application/lynx+json to value",
     parameters: { href: "." },
     expected: {
       spec: { hints: ["link"] },
       value: { href: ".", type: "application/lynx+json" }
+    }
+  },
+  {
+    description: "when explicit type",
+    should: "use provided type value",
+    parameters: { data: "Text plain", type: "text/plain" },
+    expected: {
+      spec: { hints: ["link"] },
+      value: { data: "Text plain", type: "text/plain" }
     }
   },
   {


### PR DESCRIPTION
I misinterpreted the way that placeholders were intended to be handled in partials. This resulted in the creation of custom token processing logic in partials that was unnecessary and diverged from the way tokens were processed in templates. Based on a conversation with John and a better understanding of the authoring goals of partials and placeholders, this refactoring was done to resolve issue #79 and create a better overall partial authoring experience.

The partial goals outlined were.
1. Ability to take any template section yaml, that's not using the placeholder token (`~`), and migrate it to a partial without modification and have it work.
2. Placeholders within partials are fully replaced by a matching parameter value. This allows for flexibility in overriding the partial's default implementation.