### PR TITLE
Allow `path-empty` URL values for link and submit

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "chokidar": "^1.6.1",
     "content-type-parser": "^1.0.2",
-    "handlebars": "^4.0.5",
+    "handlebars": "^4.0.11",
     "isstream": "^0.1.2",
     "json-lint": "^0.1.0",
     "logatim": "^0.9.0",

--- a/src/lib/export/lynx/validateDocument/content.js
+++ b/src/lib/export/lynx/validateDocument/content.js
@@ -3,32 +3,31 @@ const url = require("url");
 const contentTypeParser = require("content-type-parser");
 
 function validateData(value, errors) {
-  if (value.src) errors.push("'content' value with a 'data' property must not have an 'src' property");
+  if ("src" in value) errors.push("'content' value with a 'data' property must not have an 'src' property");
 
-  if (!value.type) return errors.push("'content' value with a 'data' property must have a 'type' property");
+  if (!("type" in value)) return errors.push("'content' value with a 'data' property must have a 'type' property");
   let parsed = contentTypeParser(value.type);
   if (!parsed) return errors.push("'type' must be a valid media type name");
   if (parsed.subtype.indexOf("json") < 0 && !types.isString(value.data)) errors.push("The value of 'data' must be a string if the 'type' is not application/json or a variant of application/json");
-  if (value.encoding && !(value.encoding === "utf-8" || value.encoding === "base64")) errors.push("'encoding' must be either 'utf-8' or 'base64'");
+  if ("encoding" in value && !(value.encoding === "utf-8" || value.encoding === "base64")) errors.push("'encoding' must be either 'utf-8' or 'base64'");
 }
 
 function validateSrc(value, errors) {
   try {
     let parsed = url.parse(value.src);
-    if (!parsed || parsed.href.length === 0) errors.push("'src' must be a valid URI");
   } catch (err) {
     errors.push("'src' must be a valid URI");
   }
-  if (value.data) errors.push("'content' value with an 'src' property must not have a 'data' property");
-  if (value.encoding) errors.push("'content' value with an 'src' property must not have an 'encoding' property");
+  if ("data" in value) errors.push("'content' value with an 'src' property must not have a 'data' property");
+  if ("encoding" in value) errors.push("'content' value with an 'src' property must not have an 'encoding' property");
 }
 
 function validateContent(value) {
   if (types.isNull(value)) return [];
   if (!types.isObject(value)) return ["'content' value must be an object"];
   let errors = [];
-  if (value.src) validateSrc(value, errors);
-  if (value.data) validateData(value, errors);
+  if ("src" in value) validateSrc(value, errors);
+  if ("data" in value) validateData(value, errors);
   return errors;
 }
 

--- a/src/lib/export/lynx/validateDocument/link.js
+++ b/src/lib/export/lynx/validateDocument/link.js
@@ -1,27 +1,27 @@
 const types = require("../../../../types");
 const url = require("url");
 const contentTypeParser = require("content-type-parser");
+const empty = "";
 
 function validateData(value, errors) {
-  if (value.href) errors.push("'link' value with a 'data' property must not have an 'href' property");
+  if ("href" in value) errors.push("'link' value with a 'data' property must not have an 'href' property");
 
-  if (!value.type) return errors.push("'link' value with a 'data' property must have a 'type' property");
+  if (!("type" in value)) return errors.push("'link' value with a 'data' property must have a 'type' property");
   let parsed = contentTypeParser(value.type);
   if (!parsed) return errors.push("'type' must be a valid media type name");
   if (parsed.subtype.indexOf("json") < 0 && !types.isString(value.data)) errors.push("The value of 'data' must be a string if the 'type' is not application/json or a variant of application/json");
-  if (value.encoding && !(value.encoding === "utf-8" || value.encoding === "base64")) errors.push("'encoding' must be either 'utf-8' or 'base64'");
+  if ("encoding" in value && !(value.encoding === "utf-8" || value.encoding === "base64")) errors.push("'encoding' must be either 'utf-8' or 'base64'");
 }
 
 function validateHref(value, errors) {
   try {
     let parsed = url.parse(value.href);
-    if (!parsed || parsed.href.length === 0) errors.push("'href' must be a valid URI");
   } catch (err) {
     errors.push("'href' must be a valid URI");
   }
-  if (value.data) errors.push("'link' value with an 'href' property must not have a 'data' property");
-  if (value.encoding) errors.push("'link' value with an 'href' property must not have an 'encoding' property");
-  if (value.type) {
+  if ("data" in value) errors.push("'link' value with an 'href' property must not have a 'data' property");
+  if ("encoding" in value) errors.push("'link' value with an 'href' property must not have an 'encoding' property");
+  if ("type" in value) {
     let parsed = contentTypeParser(value.type);
     if (!parsed) return errors.push("'type' must be a valid media type name");
   }
@@ -31,9 +31,9 @@ function validateLink(value) {
   if (types.isNull(value)) return [];
   if (!types.isObject(value)) return ["'link' value must be an object"];
   let errors = [];
-  if (!value.href && !value.data) errors.push("'link' value must have an 'href' or 'data' property");
-  if (value.href) validateHref(value, errors);
-  if (value.data) validateData(value, errors);
+  if (!("href" in value) && !("data" in value)) errors.push("'link' value must have an 'href' or 'data' property");
+  if ("href" in value) validateHref(value, errors);
+  if ("data" in value) validateData(value, errors);
   return errors;
 }
 

--- a/src/lib/export/lynx/validateDocument/submit.js
+++ b/src/lib/export/lynx/validateDocument/submit.js
@@ -12,10 +12,9 @@ function validateType(value, errors) {
 }
 
 function validateAction(value, errors) {
-  if (!value.action) errors.push("'submit' value must have an 'action'");
+  if (!("action" in value)) return errors.push("'submit' value must have an 'action'");
   try {
     let parsed = url.parse(value.action);
-    if (!parsed || parsed.href.length === 0) errors.push("'action' must be a valid URI");
   } catch (err) {
     errors.push("'action' must be a valid URI");
   }
@@ -26,8 +25,8 @@ function validateSubmit(value) {
   if (value && !types.isObject(value)) return ["'submit' value must be an object"];
   let errors = [];
   validateAction(value, errors);
-  if (value.type) validateType(value, errors);
-  if (value.send) validateSend(value, errors);
+  if ("type" in value) validateType(value, errors);
+  if ("send" in value) validateSend(value, errors);
   return errors;
 }
 

--- a/src/lib/export/variants-to-lynx.js
+++ b/src/lib/export/variants-to-lynx.js
@@ -1,5 +1,4 @@
 "use strict";
-
 const util = require("util");
 const path = require("path");
 const processTemplate = require("./process-template");
@@ -10,13 +9,27 @@ const jsonLint = require("json-lint");
 const types = require("../../types");
 const log = require("logatim");
 const validateLynxDocument = require("./lynx/validateDocument");
+const empty = "";
 
-handlebars.Utils.escapeExpression = function (toEscape) {
+function handlebarsEscapeExpression(toEscape) {
   if (toEscape === null || toEscape === undefined) return "";
   if (!types.isString(toEscape)) return toEscape;
 
   let stringified = JSON.stringify(toEscape);
   return stringified.substr(1, stringified.length - 2);
+}
+
+function handlebarsIsEmpty(value) {
+  if (!value && value !== empty && value !== 0) return true;
+  if (types.isArray(value) && value.length === 0) return true;
+  return false;
+}
+
+handlebars.Utils.escapeExpression = function (toEscape) {
+  return exports.handlebarsEscapeExpression(toEscape);
+};
+handlebars.Utils.isEmpty = function (value) {
+  return exports.handlebarsIsEmpty(value);
 };
 
 function exportLynxDocuments(realms, createFile, options) {
@@ -140,3 +153,5 @@ function createErrorDocumentSection(label, content) {
 
 exports.one = transformVariantToLynx;
 exports.all = exportLynxDocuments;
+exports.handlebarsEscapeExpression = handlebarsEscapeExpression;
+exports.handlebarsIsEmpty = handlebarsIsEmpty;

--- a/src/lib/json-templates/to-handlebars.js
+++ b/src/lib/json-templates/to-handlebars.js
@@ -15,7 +15,7 @@ function toHandlebars(model) {
   function writeOpenBinding(binding) {
     if (templateKey.simpleTokens.includes(binding.token)) {
       let quote = binding.token === "<" ? "\"" : "";
-      writeContent("{{#if " + binding.variable + "}}" + quote + "{{" + binding.variable + "}}" + quote + "{{else}}");
+      writeContent("{{#if " + binding.variable + " includeZero=true}}" + quote + "{{" + binding.variable + "}}" + quote + "{{else}}");
     } else if (templateKey.sectionTokens.includes(binding.token)) {
       writeContent("{{" + binding.token + binding.variable + "}}");
     } else if (templateKey.iteratorToken === binding.token) {

--- a/test/authoring/index.js
+++ b/test/authoring/index.js
@@ -1,9 +1,6 @@
 const chai = require("chai");
 const expect = chai.expect;
-const handlebars = require("handlebars");
-
-const processTemplates = require("../../src/lib/export/process-template");
-const jsonTemplates = require("../../src/lib/json-templates");
+const variantToLynx = require("../../src/lib/export/variants-to-lynx").one;
 
 var suites = [
   require("./static-content"),
@@ -29,16 +26,10 @@ function runTest(test) {
   test.options = test.options || {}; //default options to empty if not provided
   if (test.log) console.log("template", "\n" + JSON.stringify(test.template, null, 2));
   if (test.log) console.log("options", "\n" + JSON.stringify(test.options, null, 2));
-
-  var result = processTemplates(test.template, test.options, test.onFile);
-  if (test.log) console.log("process template result", "\n" + JSON.stringify(result, null, 2));
-
-  let hbContent = jsonTemplates.toHandlebars(result);
-  if (test.log) console.log("handlebars content", "\n" + hbContent);
-
-  var hbTemplate = handlebars.compile(hbContent);
-  let json = hbTemplate(test.data);
   if (test.log) console.log("data", "\n" + JSON.stringify(test.data, null, 2));
+
+  let json = variantToLynx({ template: test.template, data: test.data }, test.options, function () {});
+
   if (test.log) console.log("json", "\n" + json);
 
   let parsed = JSON.parse(json);

--- a/test/authoring/mixed-content.js
+++ b/test/authoring/mixed-content.js
@@ -34,6 +34,30 @@ var tests = [{
     options: { realm: { realm: "http://whatever" } },
     data: { boolVar: false },
     expected: { value: "Falsey", spec: { hints: ["text"] }, realm: "http://whatever" }
+  },
+  {
+    description: "Issue #83. Converting binding token '<' with empty string value",
+    template: { "foo<": "No foo" },
+    data: { foo: "" },
+    expected: { foo: "" }
+  },
+  {
+    description: "Issue #83. Converting binding token '<' with 0 number value",
+    template: { "foo<": "No foo" },
+    data: { foo: 0 },
+    expected: { foo: "0" }
+  },
+  {
+    description: "Issue #83. Converting binding token '<' with positive number value",
+    template: { "foo<": "No foo" },
+    data: { foo: 10 },
+    expected: { foo: "10" }
+  },
+  {
+    description: "Issue #83. Converting binding token '<' with negative number value",
+    template: { "foo<": "No foo" },
+    data: { foo: -10 },
+    expected: { foo: "-10" }
   }
 ];
 

--- a/test/lib/export/lynx/validateDocument/content.js
+++ b/test/lib/export/lynx/validateDocument/content.js
@@ -8,12 +8,20 @@ let tests = [{
     should: "return no errors",
     content: { src: ".", },
     expected: []
-  }, {
+  },
+  {
+    description: "valid 'content' with empty 'src'",
+    should: "return no errors",
+    content: { src: "", },
+    expected: []
+  },
+  {
     description: "valid 'content' with 'data'",
     should: "return no errors",
     content: { data: "Hello world", type: "text/plain" },
     expected: []
-  }, {
+  },
+  {
     description: "null 'content'",
     should: "return no errors",
     content: null,

--- a/test/lib/export/lynx/validateDocument/link.js
+++ b/test/lib/export/lynx/validateDocument/link.js
@@ -6,14 +6,34 @@ const validateLink = require("../../../../../src/lib/export/lynx/validateDocumen
 let tests = [{
     description: "valid 'link' with 'href'",
     should: "return no errors",
-    link: { href: ".", },
+    link: { href: "." },
     expected: []
-  }, {
+  },
+  {
+    description: "valid 'link' with empty 'href'",
+    should: "return no errors",
+    link: { href: "" },
+    expected: []
+  },
+  {
+    description: "valid 'link' with null 'href'",
+    should: "return errors",
+    link: { href: null },
+    expected: ["'href' must be a valid URI"]
+  },
+  {
     description: "valid 'link' with 'data'",
     should: "return no errors",
     link: { data: "Hello world", type: "text/plain" },
     expected: []
-  }, {
+  },
+  {
+    description: "valid 'link' with empty 'data'",
+    should: "return no errors",
+    link: { data: "", type: "text/plain" },
+    expected: []
+  },
+  {
     description: "null 'link'",
     should: "return no errors",
     link: null,
@@ -30,10 +50,20 @@ let tests = [{
     should: "return errors",
     link: {},
     expected: ["'link' value must have an 'href' or 'data' property"]
-  }, {
+  },
+  {
     description: "'link' with 'data' and 'href'",
     should: "return errors",
     link: { href: ".", type: "text/plain", data: "Hello world" },
+    expected: [
+      "'link' value with an 'href' property must not have a 'data' property",
+      "'link' value with a 'data' property must not have an 'href' property"
+    ]
+  },
+  {
+    description: "'link' with empty 'data' and empty 'href'",
+    should: "return errors",
+    link: { href: "", type: "text/plain", data: "" },
     expected: [
       "'link' value with an 'href' property must not have a 'data' property",
       "'link' value with a 'data' property must not have an 'href' property"

--- a/test/lib/export/lynx/validateDocument/submit.js
+++ b/test/lib/export/lynx/validateDocument/submit.js
@@ -26,9 +26,22 @@ let tests = [{
     should: "return errors",
     submit: {},
     expected: [
-      "'submit' value must have an 'action'",
+      "'submit' value must have an 'action'"
+    ]
+  },
+  {
+    description: "object 'submit' with null action",
+    should: "return errors",
+    submit: { action: null },
+    expected: [
       "'action' must be a valid URI"
     ]
+  },
+  {
+    description: "object 'submit' with empty action",
+    should: "return no errors",
+    submit: { action: "" },
+    expected: []
   },
   {
     description: "'submit' with valid 'type'",

--- a/test/lib/export/variants-to-lynx.js
+++ b/test/lib/export/variants-to-lynx.js
@@ -6,138 +6,199 @@ const sinon = require("sinon");
 const fs = require("fs");
 const path = require("path");
 const types = require("../../../src/types");
-const variantsToLynx = require("../../../src/lib/export/variants-to-lynx").all;
+const variantsToLynx = require("../../../src/lib/export/variants-to-lynx");
 
-var tests = [{
-    realms: [{
-      root: "/src/",
-      realm: "/src/folder-one/",
-      variants: [{
-        template: "/src/folder-one/default.lynx.yml",
-        name: "default"
-      }]
-    }],
-    options: {},
-    files: [
-      path.join("folder-one", "default.lnx")
-    ],
-    description: "when realm with one template variant",
-    should: "should emit one lnx file with path relative to root"
-  },
-  {
-    realms: [{
-      root: "/src/",
-      realm: "/src/folder-one/",
-      variants: [{
-          template: "/src/folder-one/default.lynx.yml",
-          name: "default"
-        },
-        {
-          template: "/src/folder-one/default.invalid.lynx.yml",
-          name: "default-invalid"
-        }
-      ]
-    }],
-    options: {},
-    files: [
-      path.join("folder-one", "default.lnx"),
-      path.join("folder-one", "default-invalid.lnx")
-    ],
-    description: "when realm with multiple template variants",
-    should: "should emit lnx file for each template variant with path relative to root"
-  },
-  {
-    realms: [{
-      root: "/src/",
-      realm: "/src/folder-one/",
-      variants: [{
-        content: "/src/folder-one/file.ext",
-        name: "file.ext"
-      }]
-    }],
-    options: {},
-    files: [],
-    description: "when realm with content variant",
-    should: "should ignore content variant"
-  },
-  {
-    realms: [{
-      root: "/src/",
-      realm: "/src/folder-one/",
-      variants: [{
-        template: "/src/folder-one/default.lynx.yml",
-        name: "default"
-      }]
-    }],
-    options: {},
-    template: "foo: Should be \"escaped\"",
-    expected: [{
-      foo: "Should be \"escaped\""
-    }],
-    description: "when string contains characters that should be escaped",
-    should: "should have content that contains escaped characters"
-  }, {
-    realms: [{
-      root: "/src/",
-      realm: "/src/folder-one/",
-      variants: [{
-        template: "/src/folder-one/default.lynx.yml",
-        name: "default"
-      }]
-    }],
-    options: {},
-    template: "foo: Should not be escaped",
-    expected: [{
-      foo: "Should not be escaped"
-    }],
-    description: "when string does not contain characters that should be escaped",
-    should: "should have content that does not contain escaped characters"
-  }
-];
+describe("variants to lynx module", function () {
+  describe("when exporting templates to lynx", function () {
+    var tests = [{
+        realms: [{
+          root: "/src/",
+          realm: "/src/folder-one/",
+          variants: [{
+            template: "/src/folder-one/default.lynx.yml",
+            name: "default"
+          }]
+        }],
+        options: {},
+        files: [
+          path.join("folder-one", "default.lnx")
+        ],
+        description: "when realm with one template variant",
+        should: "should emit one lnx file with path relative to root"
+      },
+      {
+        realms: [{
+          root: "/src/",
+          realm: "/src/folder-one/",
+          variants: [{
+              template: "/src/folder-one/default.lynx.yml",
+              name: "default"
+            },
+            {
+              template: "/src/folder-one/default.invalid.lynx.yml",
+              name: "default-invalid"
+            }
+          ]
+        }],
+        options: {},
+        files: [
+          path.join("folder-one", "default.lnx"),
+          path.join("folder-one", "default-invalid.lnx")
+        ],
+        description: "when realm with multiple template variants",
+        should: "should emit lnx file for each template variant with path relative to root"
+      },
+      {
+        realms: [{
+          root: "/src/",
+          realm: "/src/folder-one/",
+          variants: [{
+            content: "/src/folder-one/file.ext",
+            name: "file.ext"
+          }]
+        }],
+        options: {},
+        files: [],
+        description: "when realm with content variant",
+        should: "should ignore content variant"
+      }
+    ];
 
-function getTests() {
-  let filtered = tests.filter(test => test.include === true);
-  return filtered.length > 0 ? filtered : tests;
-}
-
-function runTest(test) {
-  var count = 0;
-
-  function onFile(path, content) {
-    if (test.files) path.should.equal(test.files[count]);
-    if (test.expected) {
-      let parsed = JSON.parse(content);
-      expect(parsed).to.deep.equal(test.expected[count]);
+    function getTests() {
+      let filtered = tests.filter(test => test.include === true);
+      return filtered.length > 0 ? filtered : tests;
     }
 
-    count++;
-  }
+    function runTest(test) {
+      var count = 0;
 
-  variantsToLynx(test.realms, onFile, test.options);
-}
+      function onFile(path, content) {
+        if (test.files) path.should.equal(test.files[count]);
+        if (test.expected) {
+          let parsed = JSON.parse(content);
+          expect(parsed).to.deep.equal(test.expected[count]);
+        }
 
-describe("when exporting templates to lynx", function () {
-  getTests().forEach(test => {
-    describe(test.description, function () {
-      beforeEach(function () {
-        var stub;
-        test.realms.forEach(realm => {
-          realm.variants.forEach(variant => {
-            if (types.isString(variant.template)) {
-              stub = stub || sinon.stub(fs, "readFileSync");
-              stub.withArgs(variant.template)
-                .returns(test.template || "foo: Hello World!");
-            }
+        count++;
+      }
+
+      variantsToLynx.all(test.realms, onFile, test.options);
+    }
+
+    getTests().forEach(test => {
+      describe(test.description, function () {
+        beforeEach(function () {
+          var stub;
+          test.realms.forEach(realm => {
+            realm.variants.forEach(variant => {
+              if (types.isString(variant.template)) {
+                stub = stub || sinon.stub(fs, "readFileSync");
+                stub.withArgs(variant.template)
+                  .returns(test.template || "foo: Hello World!");
+              }
+            });
           });
         });
-      });
 
-      afterEach(function () {
-        if (fs.readFileSync.restore) fs.readFileSync.restore();
-      });
+        afterEach(function () {
+          if (fs.readFileSync.restore) fs.readFileSync.restore();
+        });
 
-      it(test.should, function () {
-        runTest(test);
+        it(test.should, function () {
+          runTest(test);
+        });
+      });
+    });
+  });
+  describe("when escaping values during binding data", function () {
+    let tests = [{
+        description: "When expression contains characters that should be escaped",
+        input: 'to "escape"',
+        should: "should escape",
+        expected: 'to \\\"escape\\\"'
+      },
+      {
+        description: "When expression does not contain characters that should be escaped",
+        input: `don't escape`,
+        should: "should not escape",
+        expected: "don't escape"
+      }
+    ];
+
+    function runTest(test) {
+      let result = variantsToLynx.handlebarsEscapeExpression(test.input);
+      expect(test.expected).to.equal(result);
+    }
+
+    tests.forEach(test => {
+      describe(test.description, function () {
+        it(test.should, function () {
+          runTest(test);
+        });
+      });
+    });
+  });
+  describe("when testing for empty values during binding data", function () {
+    let tests = [{
+        input: [],
+        expected: true
+      },
+      {
+        input: null,
+        expected: true
+      },
+      {
+        input: undefined,
+        expected: true
+      },
+      {
+        input: false,
+        expected: true
+      },
+      {
+        input: {},
+        expected: false
+      },
+      {
+        input: { key: "Not empty" },
+        expected: false
+      },
+      {
+        input: ["Not empty"],
+        expected: false
+      },
+      {
+        input: 0,
+        expected: false
+      },
+      {
+        input: 10,
+        expected: false
+      },
+      {
+        input: -10,
+        expected: false
+      },
+      {
+        input: "",
+        expected: false
+      },
+      {
+        input: "Not empty",
+        expected: false
+      }
+    ];
+
+    function runTest(test) {
+      let result = variantsToLynx.handlebarsIsEmpty(test.input);
+      expect(test.expected).to.equal(result);
+    }
+
+    tests.forEach(test => {
+      describe(`When value is '${JSON.stringify(test.input)}'`, function () {
+        it(`Result should be '${test.expected}'`, function () {
+          runTest(test);
+        });
       });
     });
   });


### PR DESCRIPTION
- Update to validation logic to allow zero length values for link.href,
  submit.action, and content.src. Don't see much of a use for
  content.src but a `path-empty` relative URL is still valid and the
  lynx spec says it needs to be a valid URI.
- Update to handlebars configuration to not treat empty strings and `0`
  as empty values.
- Update to simple binding handlebars syntax to force call to isEmpty
  helper to check if value is empty.
- Test cases to assert behavior of changes.
- Update to latest version of handlebars.