### PR TITLE
Issue 86

### DIFF
--- a/src/cli/common.js
+++ b/src/cli/common.js
@@ -23,6 +23,10 @@ function applyDefaults(options) {
   if (options.root === undefined) options.root = ".";
   if (options.log === undefined) options.log = "error";
   if (options.flatten === undefined) options.flatten = false;
+  if (types.isString(options.flatten)) {
+    if (options.flatten.toLowerCase() === "false") options.flatten = false;
+    else options.flatten = true;
+  }
   let command = options._[0];
   if (command.toLowerCase() === "start") {
     if (options.port === undefined) options.port = 3000;

--- a/src/cli/start.js
+++ b/src/cli/start.js
@@ -22,8 +22,7 @@ function buildCommand(yargs) {
       describe: "Lint json and lynx content (true, false). [default true]"
     })
     .option("flatten", {
-      describe: "Move spec object to parent spec object if possible. [default: false]",
-      boolean: true
+      describe: "Move spec object to parent spec object if possible. [default: false]"
     })
     .option("spec.dir", {
       describe: "The directory to write files representing the spec object(s) in the template that can be extracted"

--- a/src/lib/_partials/lynx.js
+++ b/src/lib/_partials/lynx.js
@@ -6,11 +6,15 @@ function lynxPartial(parameters) {
 
   if (types.isObject(parameters)) {
     result.spec.hints = ["container"];
-    if (Object.keys(parameters).includes("value")) { //value handling
+    if ("" in parameters) { //implicit value handling
+      result.value = parameters[""];
+      delete parameters[""];
+    }
+    if ("value" in parameters) { //explicit value handling
       result.value = parameters.value;
       delete parameters.value;
     }
-    if (Object.keys(parameters).includes("spec")) { //spec handling
+    if ("spec" in parameters) { //spec handling
       result.spec = parameters.spec;
       delete parameters.spec;
     } else {

--- a/src/lib/_partials/lynx.js
+++ b/src/lib/_partials/lynx.js
@@ -6,10 +6,6 @@ function lynxPartial(parameters) {
 
   if (types.isObject(parameters)) {
     result.spec.hints = ["container"];
-    if ("" in parameters) { //implicit value handling
-      result.value = parameters[""];
-      delete parameters[""];
-    }
     if ("value" in parameters) { //explicit value handling
       result.value = parameters.value;
       delete parameters.value;

--- a/src/lib/export/lynx/flatten.js
+++ b/src/lib/export/lynx/flatten.js
@@ -12,7 +12,7 @@ function shouldCondenseObject(jsValue) {
     .every(meta => meta.binding && (templateKey.sectionTokens.includes(meta.binding.token) || templateKey.simpleTokens.includes(meta.binding.token)));
   if (dynamicValue) return false; //if the value is dynamic, then we need to keep the value key
 
-  if (exportLynx.isLynxValue(jsValue) && !exportLynx.getLynxParentNode(this)) {
+  if (exportLynx.isLynxValue(jsValue)) {
     var keys = documentKeys.filter(key => key in jsValue.value);
     if (keys.length > 0) {
       log.yellow("Unexpected document key(s) '" + keys.join("','") + "' exist in the 'value' component. Flattening disabled.").warn();

--- a/src/lib/export/process-template.js
+++ b/src/lib/export/process-template.js
@@ -7,6 +7,8 @@ const jsonTemplates = require("../json-templates");
 const lynxExport = require("./lynx");
 const log = require("logatim");
 
+jsonTemplates.partials.process.keyForNonObjectParameters = "value";
+
 function getTemplate(pathOrTemplate) {
   if (types.isObject(pathOrTemplate) || types.isArray(pathOrTemplate)) return pathOrTemplate;
   if (types.isString(pathOrTemplate)) {

--- a/src/lib/json-templates/partials/process.js
+++ b/src/lib/json-templates/partials/process.js
@@ -4,7 +4,6 @@ const traverse = require("traverse");
 const expandTokens = require("../expand-tokens");
 const partialKey = require("./partial-key");
 const types = require("../../../types");
-const emptyKey = "";
 
 function sortPlaceholders(placeholders) {
   placeholders.sort((a, b) => { //partials with wildcard replacements need to processed last
@@ -27,7 +26,7 @@ function processPlaceholders(placeholders, parameters) {
       let placeholder = key.placeholder;
       if (placeholder.wildcard) {
         if (!types.isObject(parameters)) {
-          level.value[emptyKey] = parameters; //create value template for non-object parameters
+          level.value[exports.process.keyForNonObjectParameters] = parameters; //place non object parameter in a key instead of copying keys
         } else {
           Object.keys(parameters).forEach(key => {
             level.value[key] = parameters[key];
@@ -63,3 +62,4 @@ function processPartial(partial, parameters) {
 }
 
 exports.process = processPartial;
+exports.process.keyForNonObjectParameters = "";

--- a/test/authoring/mixed-content.js
+++ b/test/authoring/mixed-content.js
@@ -34,7 +34,57 @@ var tests = [{
     options: { realm: { realm: "http://whatever" } },
     data: { boolVar: false },
     expected: { value: "Falsey", spec: { hints: ["text"] }, realm: "http://whatever" }
-  }
+  },
+  {
+    description: "Issue #86. Verify with spec and flattening.",
+    template: { ">content": { data: { realm: "http://somerealm/", ">text": "A message" } } },
+    options: { realm: { realm: "http://whatever/" }, spec: { dir: "specs", url: "/specs/" }, flatten: true },
+    onFile: (path, content) => {},
+    data: null,
+    expected: {
+      realm: "http://whatever/",
+      spec: "/specs/c78ed022973e01c91bd89c7ebb49eceb.lnxs",
+      data: {
+        realm: "http://somerealm/",
+        spec: "/specs/c389beed6629fe88882175b4fa0bba4e.lnxs",
+        value: "A message"
+      }
+    }
+  },
+  {
+    description: "Issue #86. Content with data and sources.",
+    template: {
+      ">content": {
+        type: "application/lynx+json",
+        "data>text": null,
+        sources: [{
+          media: "http//example.com/some-media",
+          type: "application/vnd.example.some-media+json",
+          data: '{ "openingForm": { "name": "BBY_DisplayWelcomeForm", "args": ["{{one}}", "{{two}}"] } }'
+        }]
+      }
+    },
+    options: { realm: { realm: "http://example.com/" }, spec: { dir: "specs", url: "/specs/" }, flatten: true },
+    onFile: (path, content) => {},
+    data: {
+      one: "I'm one",
+      two: "I'm two"
+    },
+    expected: {
+      realm: "http://example.com/",
+      spec: "/specs/c78ed022973e01c91bd89c7ebb49eceb.lnxs",
+      type: "application/lynx+json",
+      data: {
+        spec: "/specs/c389beed6629fe88882175b4fa0bba4e.lnxs",
+        value: null
+      },
+      sources: [{
+        media: "http//example.com/some-media",
+        type: "application/vnd.example.some-media+json",
+        data: `{ "openingForm": { "name": "BBY_DisplayWelcomeForm", "args": ["I'm one", "I'm two"] } }`
+      }]
+    }
+  },
 ];
 
 tests.suite = "mixed content (static and dynamic)";

--- a/test/authoring/mixed-content.js
+++ b/test/authoring/mixed-content.js
@@ -60,7 +60,7 @@ var tests = [{
         sources: [{
           media: "http//example.com/some-media",
           type: "application/vnd.example.some-media+json",
-          data: '{ "openingForm": { "name": "BBY_DisplayWelcomeForm", "args": ["{{one}}", "{{two}}"] } }'
+          data: '{ "openingForm": { "name": "A form name", "args": ["{{one}}", "{{two}}"] } }'
         }]
       }
     },
@@ -81,7 +81,7 @@ var tests = [{
       sources: [{
         media: "http//example.com/some-media",
         type: "application/vnd.example.some-media+json",
-        data: `{ "openingForm": { "name": "BBY_DisplayWelcomeForm", "args": ["I'm one", "I'm two"] } }`
+        data: `{ "openingForm": { "name": "A form name", "args": ["I'm one", "I'm two"] } }`
       }]
     }
   },

--- a/test/authoring/static-content.js
+++ b/test/authoring/static-content.js
@@ -4,6 +4,11 @@ var tests = [{
     expected: { message: "Hello World!" }
   },
   {
+    description: "Issue #86. Object with null value",
+    template: { ">container": null },
+    expected: { spec: { hints: ["container"] }, value: null }
+  },
+  {
     description: "object with text and array values",
     template: { message: "Hello World!", items: [1, 2, 3] },
     expected: { message: "Hello World!", items: [1, 2, 3] }

--- a/test/lib/export/lynx/calculate-children.js
+++ b/test/lib/export/lynx/calculate-children.js
@@ -11,7 +11,7 @@ var tests = [{
     expected: {
       bar: {
         spec: { hints: ["text"] },
-        value: { "": "Bar" }
+        value: "Bar"
       }
     }
   },
@@ -29,8 +29,8 @@ var tests = [{
           ]
         },
         value: {
-          bar: { spec: { hints: ["text"] }, value: { "": "Bar" } },
-          qux: { spec: { hints: ["text"] }, value: { "": "Qux" } }
+          bar: { spec: { hints: ["text"] }, value: "Bar" },
+          qux: { spec: { hints: ["text"] }, value: "Qux" }
         }
       }
     }
@@ -47,7 +47,7 @@ var tests = [{
           labeledBy: "label"
         },
         value: {
-          label: { spec: { hints: ["label", "text"] }, value: { "": "A link" } },
+          label: { spec: { hints: ["label", "text"] }, value: "A link" },
           href: ".",
           type: "application/lynx+json"
         }
@@ -72,7 +72,7 @@ var tests = [{
           labeledBy: "label"
         },
         value: {
-          label: { spec: { hints: ["label", "text"] }, value: { "": "Click Me" } },
+          label: { spec: { hints: ["label", "text"] }, value: "Click Me" },
           data: {
             spec: {
               hints: ["link"],
@@ -80,7 +80,7 @@ var tests = [{
               labeledBy: "label"
             },
             value: {
-              label: { spec: { hints: ["label", "text"] }, value: { "": "Click Me Too" } },
+              label: { spec: { hints: ["label", "text"] }, value: "Click Me Too" },
               type: "text/plain",
               data: "Hello, World!"
             }
@@ -99,21 +99,19 @@ var tests = [{
         spec: {
           hints: ["container"]
         },
-        value: {
-          "": [{
-              bar: {
-                spec: { hints: ["text"] },
-                value: { "": "Bar" }
-              }
-            },
-            {
-              qux: {
-                spec: { hints: ["text"] },
-                value: { "": "Qux" }
-              }
+        value: [{
+            bar: {
+              spec: { hints: ["text"] },
+              value: "Bar"
             }
-          ]
-        }
+          },
+          {
+            qux: {
+              spec: { hints: ["text"] },
+              value: "Qux"
+            }
+          }
+        ]
       }
     }
   },
@@ -129,13 +127,13 @@ var tests = [{
         value: [{
             bar: {
               spec: { hints: ["text"] },
-              value: { "": "Bar" }
+              value: "Bar"
             }
           },
           {
             qux: {
               spec: { hints: ["text"] },
-              value: { "": "Qux" }
+              value: "Qux"
             }
           }
         ]
@@ -173,11 +171,11 @@ var tests = [{
           value: {
             oneOne: {
               spec: { hints: ["text"] },
-              value: { "": "One and one" }
+              value: "One and one"
             },
             oneTwo: {
               spec: { hints: ["text"] },
-              value: { "": "One and two" }
+              value: "One and two"
             }
           }
         },
@@ -189,11 +187,11 @@ var tests = [{
           value: {
             oneOne: {
               spec: { hints: ["text"] },
-              value: { "": "One and one" }
+              value: "One and one"
             },
             oneTwo: {
               spec: { hints: ["text"] },
-              value: { "": "One and two" }
+              value: "One and two"
             }
           }
         }
@@ -219,11 +217,11 @@ var tests = [{
           "#foo": {
             bar: {
               spec: { hints: ["text"] },
-              value: { "": "Bar" }
+              value: "Bar"
             },
             qux: {
               spec: { hints: ["text"] },
-              value: { "": "Qux" }
+              value: "Qux"
             }
           },
           "^foo": null
@@ -249,7 +247,7 @@ var tests = [{
       value: {
         message: {
           spec: { hints: ["text"] },
-          value: { "": "Static content" }
+          value: "Static content"
         },
         foo: {
           "#foo": {
@@ -260,11 +258,11 @@ var tests = [{
             value: {
               bar: {
                 spec: { hints: ["text"] },
-                value: { "": "Bar" }
+                value: "Bar"
               },
               qux: {
                 spec: { hints: ["text"] },
-                value: { "": "Qux" }
+                value: "Qux"
               }
             }
           },
@@ -349,13 +347,13 @@ var tests = [{
                 "#bar": {
                   fooBar: {
                     spec: { hints: ["text"] },
-                    value: { "": "Foo and bar" }
+                    value: "Foo and bar"
                   }
                 },
                 "^bar": {
                   fooBar: {
                     spec: { hints: ["text"] },
-                    value: { "": "Foo no bar" }
+                    value: "Foo no bar"
                   }
                 }
               }
@@ -368,13 +366,13 @@ var tests = [{
                 "#bar": {
                   fooBar: {
                     spec: { hints: ["text"] },
-                    value: { "": "No foo and bar" }
+                    value: "No foo and bar"
                   }
                 },
                 "^bar": {
                   fooBar: {
                     spec: { hints: ["text"] },
-                    value: { "": "No foo and no bar" }
+                    value: "No foo and no bar"
                   }
                 }
               }
@@ -415,13 +413,13 @@ var tests = [{
             "#bar": {
               fooBar: {
                 spec: { hints: ["text"] },
-                value: { "": "Foo and bar" }
+                value: "Foo and bar"
               }
             },
             "^bar": {
               fooBar: {
                 spec: { hints: ["text"] },
-                value: { "": "Foo no bar" }
+                value: "Foo no bar"
               }
             }
           },
@@ -429,13 +427,13 @@ var tests = [{
             "#bar": {
               fooBar: {
                 spec: { hints: ["text"] },
-                value: { "": "No foo and bar" }
+                value: "No foo and bar"
               }
             },
             "^bar": {
               fooBar: {
                 spec: { hints: ["text"] },
-                value: { "": "No foo and no bar" }
+                value: "No foo and no bar"
               }
             }
           }

--- a/test/lib/export/lynx/flatten.js
+++ b/test/lib/export/lynx/flatten.js
@@ -12,7 +12,7 @@ var tests = [{
     expected: {
       message: {
         spec: { hints: ["text"] },
-        value: { "": "Hello" }
+        value: "Hello"
       }
     }
   },
@@ -25,7 +25,18 @@ var tests = [{
         hints: ["container"],
         children: [{ name: "message", hints: ["text"] }]
       },
-      message: { "": "Hello" }
+      message: "Hello"
+    }
+  },
+  {
+    description: "object container with `null` value",
+    should: "flatten not template",
+    template: { ">container": null },
+    expected: {
+      spec: {
+        hints: ["container"]
+      },
+      value: null
     }
   },
   {
@@ -41,7 +52,7 @@ var tests = [{
         ]
       },
       value: {
-        message: { "": "Hello" },
+        message: "Hello",
         realm: "http://example.com/foo/"
       }
     }
@@ -59,7 +70,7 @@ var tests = [{
         ]
       },
       value: {
-        message: { "": "Hello" },
+        message: "Hello",
         base: "http://example.com/foo/"
       }
     }
@@ -77,7 +88,7 @@ var tests = [{
         ]
       },
       value: {
-        message: { "": "Hello" },
+        message: "Hello",
         focus: "foo"
       }
     }
@@ -95,7 +106,7 @@ var tests = [{
         ]
       },
       value: {
-        message: { "": "Hello" },
+        message: "Hello",
         context: "http://example.com/foo/"
       }
     }
@@ -113,7 +124,7 @@ var tests = [{
           children: [{ name: "message", hints: ["text"] }]
         }]
       },
-      c1: { message: { "": "Hello" } }
+      c1: { message: "Hello" }
     }
   },
   {
@@ -122,7 +133,7 @@ var tests = [{
     template: { ">container": [{ ">text": "Hello" }] },
     expected: {
       spec: { hints: ["container"] },
-      value: { "": [{ spec: { hints: ["text"] }, value: { "": "Hello" } }] }
+      value: [{ spec: { hints: ["text"] }, value: "Hello" }]
     }
   },
   {
@@ -160,7 +171,7 @@ var tests = [{
       },
       value: {
         "#firstName": {
-          label: { "": "First Name" },
+          label: "First Name",
           firstName: {
             spec: {
               hints: ["line", "text"],
@@ -174,7 +185,7 @@ var tests = [{
             },
             value: { "<value": "" }
           },
-          requiredError: { "": "Required" }
+          requiredError: "Required"
         },
         "^firstName": null
       }
@@ -189,7 +200,7 @@ var tests = [{
         "#firstName": {
           "label>": "First Name",
           "firstName>line": {
-            "value": "",
+            value: "",
             "spec.input": true,
             "spec.validation": {
               required: {
@@ -215,7 +226,7 @@ var tests = [{
       },
       value: {
         "#firstName": {
-          label: { "": "First Name" },
+          label: "First Name",
           firstName: {
             spec: {
               hints: ["line", "text"],
@@ -229,7 +240,7 @@ var tests = [{
             },
             value: ""
           },
-          requiredError: { "": "Required" }
+          requiredError: "Required"
         },
         "^firstName": null
       }
@@ -241,15 +252,13 @@ var tests = [{
     template: { ">container": [{ ">container": { "message>text": "Hello" } }] },
     expected: {
       spec: { hints: ["container"] },
-      value: {
-        "": [{
-          spec: {
-            hints: ["container"],
-            children: [{ name: "message", hints: ["text"] }]
-          },
-          "message": { "": "Hello" }
-        }]
-      }
+      value: [{
+        spec: {
+          hints: ["container"],
+          children: [{ name: "message", hints: ["text"] }]
+        },
+        "message": "Hello"
+      }]
     }
   },
   {
@@ -264,21 +273,21 @@ var tests = [{
           { name: "foo" }
         ]
       },
-      message: { "": "Hello" },
+      message: "Hello",
       foo: {
         "#foo": {
           spec: {
             hints: ["container"],
             children: [{ name: "name", hints: ["text"] }]
           },
-          "name": { "": "Foo" }
+          "name": "Foo"
         },
         "^foo": {
           spec: {
             hints: ["container"],
             children: [{ name: "name", hints: ["text"] }]
           },
-          "name": { "": "No foo" }
+          "name": "No foo"
         }
       }
     }

--- a/test/lib/export/lynx/index.js
+++ b/test/lib/export/lynx/index.js
@@ -105,12 +105,6 @@ describe("lynx export module", function () {
         expected: false
       },
       {
-        description: "when value is a template for lynx value",
-        should: "be true",
-        value: { "": { spec: { hints: [] }, value: {} } },
-        expected: true
-      },
-      {
         description: "when value contains two sections that are templates for lynx values",
         should: "be true",
         value: { "#true": { spec: { hints: [] }, value: {} }, "#false": { spec: { hints: [] }, value: {} } },

--- a/test/lib/json-templates/partials/expand.js
+++ b/test/lib/json-templates/partials/expand.js
@@ -91,12 +91,12 @@ describe("expand partials module", function () {
       {
         description: "lynx text partial with string parameter",
         template: { foo: { ">text": "Foo" } },
-        expected: { foo: { spec: { hints: ["text"] }, value: { "": "Foo" } } },
+        expected: { foo: { spec: { hints: ["text"] }, value: "Foo" } },
       },
       {
         description: "container partial with array parameter",
         template: { foo: { ">container": ["Foo", "Bar"] } },
-        expected: { foo: { spec: { hints: ["container"] }, value: { "": ["Foo", "Bar"] } } },
+        expected: { foo: { spec: { hints: ["container"] }, value: ["Foo", "Bar"] } },
       },
       {
         description: "container partial with positive and negative sections for value",
@@ -106,7 +106,7 @@ describe("expand partials module", function () {
       {
         description: "partial with null parameter",
         template: { foo: { ">text": null } },
-        expected: { foo: { spec: { hints: ["text"] }, value: { "": null } } },
+        expected: { foo: { spec: { hints: ["text"] }, value: null } },
       },
       {
         description: "deeply nested partials at root",
@@ -159,13 +159,13 @@ describe("expand partials module", function () {
                     "#bar": {
                       fooBar: {
                         spec: { hints: ["text"] },
-                        value: { "": "Foo and bar" }
+                        value: "Foo and bar"
                       }
                     },
                     "^bar": {
                       fooNoBar: {
                         spec: { hints: ["text"] },
-                        value: { "": "Foo no bar" }
+                        value: "Foo no bar"
                       }
                     }
                   }
@@ -178,13 +178,13 @@ describe("expand partials module", function () {
                     "#bar": {
                       noFooBar: {
                         spec: { hints: ["text"] },
-                        value: { "": "No foo and bar" }
+                        value: "No foo and bar"
                       }
                     },
                     "^bar": {
                       noFooNoBar: {
                         spec: { hints: ["text"] },
-                        value: { "": "No foo and no bar" }
+                        value: "No foo and no bar"
                       }
                     }
                   }


### PR DESCRIPTION
This issue was resolved by handling implicit value components in the lynx partial. There is probably a better phrase than implicit value component, but it's the best I have right now.
An implicit value component is created for a partial with a wildcard placeholder when the parameter passed to the partial is not an object.
Consider as an example the `text` partial.
```yaml
>lynx:
  spec.hints: ["text"]
  *~:
```
When this partial is called with a string parameter like "Hello World" (e.g. key>text: "Hello World") we need to put "Hello World" somewhere in the new parameter set that is being passed to the lynx partial. We are currently placing that parameter on an object with a single empty key.
```javascript
{ "": "Hello World" }
```
So the resulting parameters passed to the lynx partial are
```javascript
{ spec.hints: ["text"], "": "Hello world" }
```
We do this because the following is invalid
```javascript
{ spec.hints: ["text"], "Hello world" }
```
By adding knowledge of this concept to the lynx partial it can do the right thing and treat the empty key similar to if the value component was explicitly stated.

If there are suggestions for better ways to handle calling a partial containing a wildcard placeholder with a non object parameter, I'm very welcome to those suggestion. Not in love with the way we are doing it now, but at least we're getting the proper results by adding knowledge of the concept to the lynx partial.