### PR TITLE
Fix issue with calculating section compatibility

### DIFF
--- a/src/lib/export/lynx/index.js
+++ b/src/lib/export/lynx/index.js
@@ -11,8 +11,8 @@ function getValuePortionOfLynxValue(lynxJsValue) {
 
 function validateSections(sections) {
   function sectionsAreCompatible(reference, comparison) {
-    if (isLynxValue(reference.value) ^ isLynxValue(comparison.value)) return false;
-    if (isLynxValue(reference.value) && isLynxValue(comparison.value)) return true;
+    if (exports.isLynxOrResultsInLynx(reference.value) ^ exports.isLynxOrResultsInLynx(comparison.value)) return false;
+    if (exports.isLynxOrResultsInLynx(reference.value) && exports.isLynxOrResultsInLynx(comparison.value)) return true;
     if (reference.children.length === 0 || comparison.children.length === 0) return true;
     if (reference.children.length !== comparison.children.length) return false;
     return reference.children.every((child, index) => {

--- a/test/lib/export/lynx/calculate-children.js
+++ b/test/lib/export/lynx/calculate-children.js
@@ -457,6 +457,38 @@ var tests = [{
     expected: {
       error: { message: "Children are not compatible between value templates. In order to correct this, each binding must be it's own value spec pair. Sections that are incompatible are '#truthy','^truthy'" }
     }
+  },
+  {
+    description: "nested sections result in lynx content",
+    should: "result calculate children",
+    template: {
+      "container>": {
+        child: {
+          "#foo>text": null,
+          "^foo": {
+            "#bar>text": null,
+            "^bar>text": null
+          }
+        }
+      }
+    },
+    expected: {
+      "container": {
+        "spec": {
+          "children": [{ "name": "child" }],
+          "hints": ["container"]
+        },
+        "value": {
+          "child": {
+            "#foo": { "spec": { "hints": ["text"] }, "value": null },
+            "^foo": {
+              "#bar": { "spec": { "hints": ["text"] }, "value": null },
+              "^bar": { "spec": { "hints": ["text"] }, "value": null }
+            }
+          }
+        }
+      }
+    }
   }
 ];
 
@@ -475,7 +507,8 @@ function runTest(test) {
     if (test.include || test.log) console.log("result", "\n" + JSON.stringify(result, null, 2));
     expect(result).to.deep.equal(test.expected);
   } catch (err) {
-    expect(test.expected.error.message).to.equal(err.message);
+    if (test.expected.error) expect(test.expected.error.message).to.equal(err.message);
+    else throw err;
   }
 }
 


### PR DESCRIPTION
A valid authoring scenario, multiple nested sections that result in lynx content, was flagged as incompatible sections.