### PR TITLE
Resolves bug processing subset of placeholders

### DIFF
--- a/src/lib/json-templates/partials/process.js
+++ b/src/lib/json-templates/partials/process.js
@@ -19,8 +19,11 @@ function processPlaceholders(traverseNode, placeholderKeys, parameters, used) {
       let placeholderKey = placeholderKeys.find(p => p.source === key);
       if (placeholderKey) {
         let pairs = getPairsForPlaceholder(placeholderKey, parameters);
-        if (!pairs) setValue(acc, placeholderKey.name, value[placeholderKey.source]); //use value in partial
-        else {
+        if (!pairs) { //use value in partial
+          let placeholder = placeholderKey.placeholder;
+          let newKey = placeholderKey.source.replace(placeholder.token + (placeholder.explicit ? placeholder.variable : ''), '');
+          setValue(acc, newKey, value[placeholderKey.source]);
+        } else {
           //use value in parameters set
           pairs.forEach(pair => {
             acc[pair.key] = pair.value;

--- a/src/lib/json-templates/template-key.js
+++ b/src/lib/json-templates/template-key.js
@@ -19,12 +19,11 @@ function parse(key, partialSyntax) {
     if (match.index === 0 && !match[1]) parsed.name = match[2]; //key name doesn't have tokens
     else {
       if (match[1]) { //if we have a template token then push the template info
-        let variable = match[2] || parsed.name;
-        if (!variable) throw Error("Token must have explicit variable if 'name' does not exist.");
-        let token = match[1];
-        if (exports.partialToken === token) parsed.partial = { token: token, variable: variable };
-        else if (exports.placeHolderToken === token) parsed.placeholder = { variable: variable };
-        else parsed.binding = { token: token, variable: variable };
+        let result = { token: match[1], variable: match[2] || parsed.name, explicit: !!match[2] };
+        if (!result.variable) throw Error("Token must have explicit variable if 'name' does not exist.");
+        if (exports.partialToken === result.token) parsed.partial = result
+        else if (exports.placeHolderToken === result.token) parsed.placeholder = result;
+        else parsed.binding = result;
       }
     }
   }

--- a/test/lib/json-templates/partials/partial-key.js
+++ b/test/lib/json-templates/partials/partial-key.js
@@ -16,12 +16,12 @@ let tests = [{
   {
     description: "key with name and variable",
     key: "foo~",
-    expected: { name: "foo", placeholder: { wildcard: false, variable: "foo" } }
+    expected: { name: "foo", placeholder: { token: "~", wildcard: false, variable: "foo", explicit: false } }
   },
   {
     description: "key with name '<' binding and variable",
     key: "foo<~",
-    expected: { name: "foo", placeholder: { wildcard: false, variable: "foo" } }
+    expected: { name: "foo", placeholder: { token: "~", wildcard: false, variable: "foo", explicit: false } }
   },
   {
     description: "key with name '<' binding, partial reference, and variable",
@@ -31,62 +31,62 @@ let tests = [{
   {
     description: "key with name '=' binding and variable",
     key: "foo=~",
-    expected: { name: "foo", placeholder: { wildcard: false, variable: "foo" } }
+    expected: { name: "foo", placeholder: { token: "~", wildcard: false, variable: "foo", explicit: false } }
   },
   {
     description: "key with name '#' binding and variable",
     key: "foo#~",
-    expected: { name: "foo", placeholder: { wildcard: false, variable: "foo" } }
+    expected: { name: "foo", placeholder: { token: "~", wildcard: false, variable: "foo", explicit: false } }
   },
   {
     description: "key with name '^' binding and variable",
     key: "foo^~",
-    expected: { name: "foo", placeholder: { wildcard: false, variable: "foo" } }
+    expected: { name: "foo", placeholder: { token: "~", wildcard: false, variable: "foo", explicit: false } }
   },
   {
     description: "key with name '>' partial and variable",
     key: "foo>~",
-    expected: { name: "foo", placeholder: { wildcard: false, variable: "foo" } }
+    expected: { name: "foo", placeholder: { token: "~", wildcard: false, variable: "foo", explicit: false } }
   },
   {
     description: "key with name '<' binding and named variable",
     key: "foo<~foo",
-    expected: { name: "foo", placeholder: { wildcard: false, variable: "foo" } }
+    expected: { name: "foo", placeholder: { token: "~", wildcard: false, variable: "foo", explicit: true } }
   },
   {
     description: "key with name '=' binding and named variable",
     key: "foo=~foo",
-    expected: { name: "foo", placeholder: { wildcard: false, variable: "foo" } }
+    expected: { name: "foo", placeholder: { token: "~", wildcard: false, variable: "foo", explicit: true } }
   },
   {
     description: "key with name '#' binding and named variable",
     key: "foo#~foo",
-    expected: { name: "foo", placeholder: { wildcard: false, variable: "foo" } }
+    expected: { name: "foo", placeholder: { token: "~", wildcard: false, variable: "foo", explicit: true } }
   },
   {
     description: "key with name '^' binding and named variable",
     key: "foo^~foo",
-    expected: { name: "foo", placeholder: { wildcard: false, variable: "foo" } }
+    expected: { name: "foo", placeholder: { token: "~", wildcard: false, variable: "foo", explicit: true } }
   },
   {
     description: "key with name '>' partial and named variable",
     key: "foo>~foo",
-    expected: { name: "foo", placeholder: { wildcard: false, variable: "foo" } }
+    expected: { name: "foo", placeholder: { token: "~", wildcard: false, variable: "foo", explicit: true } }
   },
   {
     description: "key with name with dashes and variable",
     key: "foo-name~",
-    expected: { name: "foo-name", placeholder: { wildcard: false, variable: "foo-name" } }
+    expected: { name: "foo-name", placeholder: { token: "~", wildcard: false, variable: "foo-name", explicit: false } }
   },
   {
     description: "key with name and named variable",
     key: "foo~foo",
-    expected: { name: "foo", placeholder: { wildcard: false, variable: "foo" } }
+    expected: { name: "foo", placeholder: { token: "~", wildcard: false, variable: "foo", explicit: true } }
   },
   {
     description: "key with name with dashes and named variale with dashes",
     key: "foo-name~bar-name",
-    expected: { name: "foo-name", placeholder: { wildcard: false, variable: "bar-name" } }
+    expected: { name: "foo-name", placeholder: { token: "~", wildcard: false, variable: "bar-name", explicit: true } }
   },
   {
     description: "wildcard key name only",
@@ -96,7 +96,7 @@ let tests = [{
   {
     description: "wildcard key and variable",
     key: "*~",
-    expected: { name: "*", placeholder: { wildcard: true, variable: "*" } }
+    expected: { name: "*", placeholder: { token: "~", wildcard: true, variable: "*", explicit: false } }
   }
 ];
 

--- a/test/lib/json-templates/partials/process.js
+++ b/test/lib/json-templates/partials/process.js
@@ -318,6 +318,28 @@ let tests = [{
       foo: { bar: "qux" }
     }
   },
+  {
+    description: "When placeholder includes explicit partial reference and no matching parameter",
+    should: "should use key name with partial reference in result",
+    partial: {
+      "optional>foo~bar": "default"
+    },
+    parameters: {},
+    expected: {
+      "optional>foo": "default"
+    }
+  },
+  {
+    description: "When placeholder includes implicit partial reference and no matching parameter",
+    should: "should use key name with partial reference in result",
+    partial: {
+      "optional>foo~": "default"
+    },
+    parameters: {},
+    expected: {
+      "optional>foo": "default"
+    }
+  },
 ];
 
 function getTests() {

--- a/test/lib/json-templates/template-key.js
+++ b/test/lib/json-templates/template-key.js
@@ -18,7 +18,7 @@ let tests = [{
     key: "foo#",
     expected: {
       name: "foo",
-      binding: { token: "#", variable: "foo" }
+      binding: { token: "#", variable: "foo", explicit: false }
     }
   },
   {
@@ -26,7 +26,7 @@ let tests = [{
     key: "foo<~",
     expected: {
       name: "foo",
-      binding: { token: "<", variable: "~" }
+      binding: { token: "<", variable: "~", explicit: true }
     }
   },
   {
@@ -34,7 +34,7 @@ let tests = [{
     key: "foo-name#",
     expected: {
       name: "foo-name",
-      binding: { token: "#", variable: "foo-name" }
+      binding: { token: "#", variable: "foo-name", explicit: false }
     }
   },
   {
@@ -42,7 +42,7 @@ let tests = [{
     key: "foo#bar",
     expected: {
       name: "foo",
-      binding: { token: "#", variable: "bar" }
+      binding: { token: "#", variable: "bar", explicit: true }
     }
   },
   {
@@ -50,7 +50,7 @@ let tests = [{
     key: "foo-name#bar-name",
     expected: {
       name: "foo-name",
-      binding: { token: "#", variable: "bar-name" }
+      binding: { token: "#", variable: "bar-name", explicit: true }
     }
   },
   {
@@ -58,8 +58,8 @@ let tests = [{
     key: "foo#bar>partial",
     expected: {
       name: "foo",
-      binding: { token: "#", variable: "bar" },
-      partial: { token: ">", variable: "partial" }
+      binding: { token: "#", variable: "bar", explicit: true },
+      partial: { token: ">", variable: "partial", explicit: true }
     }
   },
   {
@@ -67,8 +67,8 @@ let tests = [{
     key: "foo-name#bar-name>partial-name",
     expected: {
       name: "foo-name",
-      binding: { token: "#", variable: "bar-name" },
-      partial: { token: ">", variable: "partial-name" }
+      binding: { token: "#", variable: "bar-name", explicit: true },
+      partial: { token: ">", variable: "partial-name", explicit: true }
     }
   },
   {
@@ -76,8 +76,8 @@ let tests = [{
     key: "foo#>",
     expected: {
       name: "foo",
-      binding: { token: "#", variable: "foo" },
-      partial: { token: ">", variable: "foo" }
+      binding: { token: "#", variable: "foo", explicit: false },
+      partial: { token: ">", variable: "foo", explicit: false }
     }
   },
   {
@@ -85,8 +85,8 @@ let tests = [{
     key: "foo<>",
     expected: {
       name: "foo",
-      binding: { token: "<", variable: "foo" },
-      partial: { token: ">", variable: "foo" }
+      binding: { token: "<", variable: "foo", explicit: false },
+      partial: { token: ">", variable: "foo", explicit: false }
     }
   },
   {
@@ -94,19 +94,19 @@ let tests = [{
     key: "foo#>partial",
     expected: {
       name: "foo",
-      binding: { token: "#", variable: "foo" },
-      partial: { token: ">", variable: "partial" }
+      binding: { token: "#", variable: "foo", explicit: false },
+      partial: { token: ">", variable: "partial", explicit: true }
     }
   },
   {
     description: "key with binding only",
     key: "#bar",
-    expected: { binding: { token: "#", variable: "bar" } }
+    expected: { binding: { token: "#", variable: "bar", explicit: true } }
   },
   {
     description: "key with partial only",
     key: ">partial",
-    expected: { partial: { token: ">", variable: "partial" } }
+    expected: { partial: { token: ">", variable: "partial", explicit: true } }
   }
 ];
 


### PR DESCRIPTION
This commit resolves an issue when a placeholder has a partial reference and is called with a parameter set that is empty. Before this fix, the resulting key from processing dropped the partial reference. The new tests in test/lib/json-templates/partials/process.js illustrate the issue.